### PR TITLE
Add migrate script; drop files sync script

### DIFF
--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+export DRUSH=/app/vendor/bin/drush
+
+echo "Resetting all migrations"
+for m in d7_user_role d7_user d7_taxonomy_term_chart_type d7_taxonomy_term_global_topics d7_taxonomy_term_indicators d7_taxonomy_term_outcomes d7_file d7_file_media_image group_media_image node_news group_node_news group_users
+do
+  $DRUSH migrate:reset $m
+done
+
+echo "Migrating D7 user and roles"
+$DRUSH migrate:import d7_users --execute-dependencies --force
+echo "... associate User entities with Group entities"
+$DRUSH migrate:import group_users --force
+
+echo "Migrating D7 taxonomy data"
+$DRUSH migrate:import --group=migrate_drupal_7_taxo --force
+
+echo "Migrating D7 files"
+$DRUSH migrate:import d7_file --force
+echo "Migrating D7 images to Image media entities"
+$DRUSH migrate:import d7_file_media_image --force
+echo "... associate Image media entities with Group entities"
+$DRUSH migrate:import group_media_image --force
+
+echo "Migrate D7 news nodes"
+$DRUSH migrate:import node_news --force
+echo "... associate News nodes with Group entities"
+$DRUSH migrate:import group_node_news --force
+
+echo ".... DONE"

--- a/migrate-scripts/sync-files.sh
+++ b/migrate-scripts/sync-files.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-D7_PROJECT_ID=$1
-D7_PROJECT_ENV=$2
-APPSERVICE=deptinternet
-
-platform mount:download -p $D7_PROJECT_ID -e $D7_PROJECT_ENV -A $APPSERVICE -m "/public_html/sites/default/files" --exclude "css*" --exclude "js*" --exclude="status_check*" --exclude="ctools*" --target /app/imports/files/ -y


### PR DESCRIPTION
Expecting to add to this over time: aliases, redirects etc to follow.

NB: MySQL timeouts on prod cluster mean long running migrations like the files one may need to be batch executed if running from scratch. Incremental updates should be fine.