### PR TITLE
Menus tidyup + composer tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /web/modules/origins/
 /web/themes/contrib/
 #/web/themes/custom/
+/web/themes/origins/
 /web/profiles/contrib/
 /web/profiles/custom/
 /web/profiles/origins/

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "cweagans/composer-patches": "^1.7",
         "deaemth/easychart": "^3.1",
         "dof-dss/nicsdru_origins_modules": "^0.9",
+        "dof-dss/nicsdru_origins_theme": "^0.4.0",
         "drupal/admin_toolbar": "^3.0",
         "drupal/adminimal_theme": "^1.6",
         "drupal/chosen": "^3.0",
@@ -85,7 +86,6 @@
         "drupal/field_group": "^3.2",
         "drupal/flag": "^4.0@beta",
         "drupal/geolocation": "^3.7",
-        "drupal/group_content_menu": "^1.1",
         "drupal/group_entityqueue": "^1.0@beta",
         "drupal/groupmedia": "^2.0@alpha",
         "drupal/handy_cache_tags": "^1.1",
@@ -170,6 +170,9 @@
             ],
             "web/profiles/origins/{$name}": [
                 "dof-dss/nicsdru_origins_profile"
+            ],
+            "web/themes/origins": [
+                "dof-dss/nicsdru_origins_theme"
             ],
             "web/modules/contrib/{$name}": [
                 "type:drupal-module"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "929531ad18f7dc7831929d0dbc529d2b",
+    "content-hash": "ca941b0e19fe0e2b83fb1f567c2245b8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1412,6 +1412,45 @@
             ],
             "description": "Generic modules for DOF-DSS Drupal sites",
             "time": "2021-10-24T12:23:04+00:00"
+        },
+        {
+            "name": "dof-dss/nicsdru_origins_theme",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dof-dss/nicsdru_origins_theme.git",
+                "reference": "55981f0d765bc698472e0518899ad477266ed048"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dof-dss/nicsdru_origins_theme/zipball/55981f0d765bc698472e0518899ad477266ed048",
+                "reference": "55981f0d765bc698472e0518899ad477266ed048",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "type": "drupal-custom-theme",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Corbett",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Drupal 8 base theme",
+            "homepage": "https://github.com/dof-dss/nicsdru_origins_theme",
+            "keywords": [
+                "drupal",
+                "theme"
+            ],
+            "support": {
+                "source": "https://github.com/dof-dss/nicsdru_origins_theme/tree/0.4.0"
+            },
+            "time": "2021-11-04T19:23:44+00:00"
         },
         {
             "name": "drupal/admin_toolbar",
@@ -3965,60 +4004,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/group",
                 "issues": "https://drupal.org/project/issues/group"
-            }
-        },
-        {
-            "name": "drupal/group_content_menu",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/group_content_menu.git",
-                "reference": "8.x-1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/group_content_menu-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "73972de25735e77079712536007193364cda9635"
-            },
-            "require": {
-                "drupal/core": "^8.6 | ^9.0",
-                "drupal/group": "^1.0@RC"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1625840228",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Lucas Hedding",
-                    "homepage": "https://www.drupal.org/u/heddn",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "heddn",
-                    "homepage": "https://www.drupal.org/user/1463982"
-                }
-            ],
-            "description": "Provides features for a menu per group",
-            "homepage": "https://www.drupal.org/project/group_content_menu",
-            "keywords": [
-                "Drupal"
-            ],
-            "support": {
-                "source": "https://git.drupalcode.org/project/group_content_menu",
-                "issues": "https://www.drupal.org/project/issues/group_content_menu"
             }
         },
         {


### PR DESCRIPTION
* Getting rid of group_menu_content config and references (content has been purged from prod db to make config import work)
* Moving origins theme into an origins folder, rather than custom, because it's technically shared between builds as a base theme.