### PR TITLE
Tweak migrate script and add cron entry for nightly run

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -152,6 +152,6 @@ crons:
   d7db:
     spec: '0 1 * * *'
     cmd: 'migrate-scripts/sync-db.sh $D7_PROJECT_ID $D7_PROJECT_ENV'
-#  migrate:
-#    spec: '30 2 * * *'
-#    cmd: 'migrate-scripts/migrate.sh'
+  migrate:
+    spec: '30 2 * * *'
+    cmd: 'migrate-scripts/migrate.sh'

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 export DRUSH=/app/vendor/bin/drush
-export MIGRATIONS=d7_taxonomy_term_chart_type d7_taxonomy_term_global_topics d7_taxonomy_term_indicators \
-        d7_taxonomy_term_outcomes users d7_file d7_file_media_image d7_file_media_video node_easychart \
-        node_news group_users group_media_image group_media_video group_node_easychart group_node_news
+export MIGRATIONS="d7_taxonomy_term_chart_type d7_taxonomy_term_global_topics d7_taxonomy_term_indicators \
+        d7_taxonomy_term_outcomes users group_users d7_file d7_file_media_image d7_file_media_video \
+          group_media_image group_media_video node_easychart group_node_easychart node_news group_node_news"
 
-if [ -z ${PLATFORM_BRANCH} ]
+if [ -z ${PLATFORM_BRANCH} ] && [ -z ${LANDO} ];
 then
-  # Not running on a platform environment, exit.
+  # Not running on a platform environment, or Lando, so exit.
+  echo "Couldn't detect platform branch or Lando variable, exiting."
   exit 1
 fi
 
 # Only execute on the main environment.
-if [ "${PLATFORM_BRANCH}" == "main" ]
+if [[ "${PLATFORM_BRANCH}" == "main" || "${LANDO}" == "ON" ]];
 then
   echo "Resetting all migrations"
   for m in $MIGRATIONS
@@ -25,8 +26,8 @@ then
     $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_group_$type/config/install -y
   done
 
-  echo "Migrating D7 taxonomy data"
-  $DRUSH migrate:import --group=migrate_drupal_7_taxo --force
+#  echo "Migrating D7 taxonomy data"
+#  $DRUSH migrate:import --group=migrate_drupal_7_taxo --force
 
   echo "Migrating D7 user and roles"
   $DRUSH migrate:import users --force


### PR DESCRIPTION
Commenting out taxo import (for now) due to some unexpected SQL exceptions thrown during run. These change very infrequently, so likely not too risky at this stage.

Runtime (without d7_files was about 3 mins). With d7_files, it'll potentially be up to 2-3hrs, subject to the number of changes detected along the way.