### PR TITLE
Make node migrate handler a little more capable of handling failure.

### DIFF
--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 export DRUSH=/app/vendor/bin/drush
 export MIGRATIONS="d7_taxonomy_term_chart_type d7_taxonomy_term_global_topics d7_taxonomy_term_indicators \
-        d7_taxonomy_term_outcomes users group_users d7_file d7_file_media_image d7_file_media_video \
-          group_media_image group_media_video node_easychart group_node_easychart node_news group_node_news"
+        d7_taxonomy_term_outcomes users d7_file d7_file_media_image d7_file_media_video \
+          group_media_image group_media_video node_easychart node_news"
 
 if [ -z ${PLATFORM_BRANCH} ] && [ -z ${LANDO} ];
 then
@@ -21,7 +21,9 @@ then
   done
 
   echo "Make sure active config matches that from migrate modules"
-  for type in users files nodes taxo
+  $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install -y
+
+  for type in users files nodes
   do
     $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_group_$type/config/install -y
   done
@@ -31,8 +33,6 @@ then
 
   echo "Migrating D7 user and roles"
   $DRUSH migrate:import users --force
-  echo "... associate User entities with Group entities"
-  $DRUSH migrate:import group_users --force
 
   echo "Migrating D7 files and media entities"
   $DRUSH migrate:import d7_file --force
@@ -48,8 +48,6 @@ then
   do
     echo "Migrate D7 ${type} nodes"
     $DRUSH migrate:import node_$type --force
-    echo "... associate ${type} nodes with Group entities"
-    $DRUSH migrate:import group_node_$type --force
   done
 
   echo ".... DONE"

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/dept_migrate_group_nodes.services.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/dept_migrate_group_nodes.services.yml
@@ -1,6 +1,6 @@
 services:
   dept_migrate_group_nodes.eventsubscriber.post:
     class: 'Drupal\dept_migrate_group_nodes\EventSubscriber\NodeEntityMigrateSubscriber'
-    arguments: ['@entity_type.manager', '@dept_migrate.migrate_support']
+    arguments: ['@entity_type.manager', '@dept_migrate.migrate_support', '@logger.factory']
     tags:
       - { name: 'event_subscriber' }

--- a/web/modules/custom/dept_migrate/src/MigrateSupport.php
+++ b/web/modules/custom/dept_migrate/src/MigrateSupport.php
@@ -152,8 +152,10 @@ class MigrateSupport {
           ])->fetchAllAssoc('gid');
 
       $node_group_ids = [];
-      foreach ($group_content_data as $gc_id => $row) {
-        $node_group_ids[] = $row->gid;
+      if (!empty($group_content_data)) {
+        foreach ($group_content_data as $gc_id => $row) {
+          $node_group_ids[] = $row->gid;
+        }
       }
 
       // Compare current groups to current domains, if they differ then


### PR DESCRIPTION
Fixes for migrate script, too.

Rollout for this will need all migrate modules reinstalled, past group_node_* and group_users migration tables dropped and then a migrate import with --update flag for node_news (at least).

Script takes about 5 mins end to end, with no or few changes. Up to, possibly over, 30 mins for a more comprehensive import or updates.