### PR TITLE
Add redirects migration and row prepare subscriber event

### DIFF
--- a/config/sync/migrate_plus.migration.redirects.yml
+++ b/config/sync/migrate_plus.migration.redirects.yml
@@ -1,0 +1,34 @@
+uuid: 06b89930-6d76-447c-a168-e747f552b889
+langcode: en
+status: true
+dependencies: {  }
+id: redirects
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - dept_sites
+migration_group: migrate_group_redirects
+label: 'URL Redirects'
+source:
+  plugin: d7_path_redirect
+process:
+  rid: rid
+  uid: uid
+  redirect_source/path: source
+  redirect_source/query:
+    plugin: d7_redirect_source_query
+    source: source_options
+  redirect_redirect/uri:
+    plugin: d7_path_redirect
+    source:
+      - redirect
+      - redirect_options
+  language:
+    plugin: default_value
+    source: language
+    default_value: und
+  status_code: status_code
+destination:
+  plugin: 'entity:redirect'
+migration_dependencies: null

--- a/config/sync/migrate_plus.migration_group.migrate_group_redirects.yml
+++ b/config/sync/migrate_plus.migration_group.migrate_group_redirects.yml
@@ -1,0 +1,10 @@
+uuid: 0506e26c-25e8-49d1-86ca-83493da508f0
+langcode: en
+status: true
+dependencies: {  }
+id: migrate_group_redirects
+label: migrate_group_redirects
+description: ''
+source_type: null
+module: null
+shared_configuration: null

--- a/web/modules/custom/dept_migrate/config/install/migrate_plus.migration.redirects.yml
+++ b/web/modules/custom/dept_migrate/config/install/migrate_plus.migration.redirects.yml
@@ -1,0 +1,26 @@
+id: redirects
+label: URL Redirects
+migration_group: migrate_group_redirects
+migration_tags:
+  - dept_sites
+source:
+  plugin: d7_path_redirect
+process:
+  rid: rid
+  uid: uid
+  redirect_source/path: source
+  redirect_source/query:
+    plugin: d7_redirect_source_query
+    source: source_options
+  redirect_redirect/uri:
+    plugin: d7_path_redirect
+    source:
+      - redirect
+      - redirect_options
+  language:
+    plugin: default_value
+    source: language
+    default_value: und
+  status_code: status_code
+destination:
+  plugin: entity:redirect

--- a/web/modules/custom/dept_migrate/dept_migrate.services.yml
+++ b/web/modules/custom/dept_migrate/dept_migrate.services.yml
@@ -2,6 +2,11 @@ services:
   dept_migrate.migrate_uuid_lookup_manager:
     class: 'Drupal\dept_migrate\MigrateUuidLookupManager'
     arguments: ['@entity_type.manager', '@database']
+  dept_migrate.eventsubscriber.migrate.redirect_update:
+    class: Drupal\dept_migrate\EventSubscriber\RedirectMigrateSubscriber
+    arguments: ['@entity_type.manager', '@dept_migrate.migrate_uuid_lookup_manager', '@logger.factory']
+    tags:
+      - { name: event_subscriber }
   dept_migrate.eventsubscriber.migrate.entity_ref_update:
     class: Drupal\dept_migrate\EventSubscriber\PostMigrationEntityRefUpdateSubscriber
     arguments: ['@entity_field.manager', '@dept_migrate.migrate_uuid_lookup_manager', '@logger.factory']

--- a/web/modules/custom/dept_migrate/src/EventSubscriber/RedirectMigrateSubscriber.php
+++ b/web/modules/custom/dept_migrate/src/EventSubscriber/RedirectMigrateSubscriber.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\dept_migrate\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\dept_migrate\MigrateUuidLookupManager;
+use Drupal\migrate_plus\Event\MigrateEvents;
+use Drupal\migrate\Event\MigratePreRowSaveEvent;
+use Drupal\migrate_plus\Event\MigratePrepareRowEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class RedirectMigrateSubscriber.
+ */
+class RedirectMigrateSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\dept_migrate\MigrateUuidLookupManager
+   */
+  protected $lookupManager;
+
+  /**
+   * Drupal\Core\Logger\LoggerChannelFactory definition.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $logger;
+
+  /**
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager service.
+   * @param \Drupal\dept_migrate\MigrateUuidLookupManager $lookup_manager
+   *   Lookup Manager.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $logger
+   *   Drupal logger.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager,
+                              MigrateUuidLookupManager $lookup_manager,
+                              LoggerChannelFactory $logger) {
+
+    $this->entityTypeManager = $entity_type_manager;
+    $this->lookupManager = $lookup_manager;
+    $this->logger = $logger->get('dept_migrate');
+  }
+
+  /**
+   * Callback for preparing the migration row.
+   *
+   * @param \Drupal\migrate_plus\Event\MigratePrepareRowEvent $event
+   *   The event object to prepare.
+   */
+  public function onPrepareRow(MigratePrepareRowEvent $event) {
+    if ($event->getMigration()->id() === 'redirects') {
+      $source = $event->getRow()->getSourceProperty('source');
+      $destination = $event->getRow()->getSourceProperty('redirect');
+
+      // Source: if it's an internal node path update the node id to the D9 equivalent.
+      $source_matches = [];
+      preg_match('|node/(\d+)|', $source, $source_matches);
+      $old_nid = $source_matches[1];
+
+      if (!empty($old_nid)) {
+        $d9_info = $this->lookupManager->lookupBySourceNodeId([$old_nid]);
+        $d9_nid = reset($d9_info)['nid'] ?? 0;
+
+        if (!empty($d9_nid)) {
+          $d9_source = preg_replace('|node/(\d+)|', 'node/' . $d9_nid, $source);
+          $event->getRow()->setSourceProperty('source', $d9_source);
+        }
+      }
+
+      // Destination: if it's an internal node path update the node id to the D9 equivalent.
+      $dest_matches = [];
+      preg_match('|node/(\d+)|', $destination, $dest_matches);
+      $old_nid = $dest_matches[1];
+
+      if (!empty($old_nid)) {
+        $d9_info = $this->lookupManager->lookupBySourceNodeId([$old_nid]);
+        $d9_nid = reset($d9_info)['nid'] ?? 0;
+
+        if (!empty($d9_nid)) {
+          $d9_dest = preg_replace('|node/(\d+)|', 'node/' . $d9_nid, $destination);
+          $event->getRow()->setSourceProperty('redirect', $d9_dest);
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    $events = [];
+    // NB: MigrateEvents is a migrate_plus namespace.
+    $events[MigrateEvents::PREPARE_ROW] = ['onPrepareRow'];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
Rather than try and wrestle migrate pseudo fields in to break up/rewrite node paths, it's easier to add an event subscriber which can prepare the row before it saves. That can then detect any internal node paths and update the numerical value to the correct D9 version, if it exists.