### PR TITLE
Remove publication attachment field (stray config)

### DIFF
--- a/config/sync/core.entity_form_display.node.publication.default.yml
+++ b/config/sync/core.entity_form_display.node.publication.default.yml
@@ -204,4 +204,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_attachment: true

--- a/config/sync/core.entity_view_display.node.publication.default.yml
+++ b/config/sync/core.entity_view_display.node.publication.default.yml
@@ -125,5 +125,6 @@ content:
     weight: 11
     region: content
 hidden:
+  field_attachment: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.publication.teaser.yml
+++ b/config/sync/core.entity_view_display.node.publication.teaser.yml
@@ -38,6 +38,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_attachment: true
   field_external_publication: true
   field_global_topics: true
   field_last_updated: true


### PR DESCRIPTION
Needs drush cim run twice (complains first time, removes the field second time)