### PR TITLE
Book module config, collection and book migrate config

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -155,9 +155,9 @@ crons:
   sync_files:
     spec: '30 0 * * *'
     cmd: 'migrate-scripts/sync-private-files.sh $D7_PROJECT_ID $D7_PROJECT_ENV'
-#  migrate:
-#    spec: '30 2 * * *'
-#    cmd: 'migrate-scripts/migrate.sh'
+  migrate:
+    spec: '30 2 * * *'
+    cmd: 'migrate-scripts/migrate.sh | tee /app/imports/last-migrate-output.txt'
   drupal:
     spec: '*/15 * * * *'
     cmd: 'vendor/bin/drush cron'

--- a/config/sync/book.settings.yml
+++ b/config/sync/book.settings.yml
@@ -1,0 +1,8 @@
+_core:
+  default_config_hash: i-_2TVi6FUEAqBgNRJkt6aaYmiw1k_LTrXzJS6wlZ4U
+allowed_types:
+  - book
+block:
+  navigation:
+    mode: 'all pages'
+child_type: book

--- a/config/sync/core.base_field_override.node.book.promote.yml
+++ b/config/sync/core.base_field_override.node.book.promote.yml
@@ -1,0 +1,24 @@
+uuid: 7d51231c-47a2-4840-b263-2607e030de38
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.book
+_core:
+  default_config_hash: rYbAZX1eKDo7CVRnBnpYgdmk8HQo5IcKhzePCx9LCZY
+id: node.book.promote
+field_name: promote
+entity_type: node
+bundle: book
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -5,6 +5,7 @@ module:
   admin_toolbar_tools: 0
   block: 0
   block_content: 0
+  book: 0
   breakpoint: 0
   chosen: 0
   chosen_field: 0

--- a/config/sync/migrate_plus.migration.dept_book.yml
+++ b/config/sync/migrate_plus.migration.dept_book.yml
@@ -1,0 +1,37 @@
+uuid: f72dd208-58b8-48b7-be5b-0972e509b11b
+langcode: en
+status: true
+dependencies: {  }
+id: dept_book
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - dept_sites
+migration_group: migrate_group_book
+label: 'Departmental books'
+source:
+  plugin: book
+process:
+  nid:
+    -
+      plugin: d7_node_lookup
+      source: nid
+  book/bid:
+    -
+      plugin: d7_node_lookup
+      source: bid
+  book/weight:
+    -
+      plugin: get
+      source: weight
+  book/pid:
+    -
+      plugin: migration_lookup
+      migration: dept_book
+destination:
+  plugin: book
+migration_dependencies:
+  required:
+    - user
+    - node_collection

--- a/config/sync/migrate_plus.migration.node_collection.yml
+++ b/config/sync/migrate_plus.migration.node_collection.yml
@@ -1,0 +1,66 @@
+uuid: 8e702165-1169-4059-8bf6-554cbe11f236
+langcode: en
+status: true
+dependencies: {  }
+id: node_collection
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: alterFieldInstanceMigration
+cck_plugin_method: null
+migration_tags:
+  - dept_sites
+migration_group: migrate_group_nodes
+label: 'Collection content type nodes'
+source:
+  plugin: d7_dept_node
+  node_type: book
+  track_changes: true
+process:
+  langcode:
+    -
+      plugin: default_value
+      source: language
+      default_value: en
+  title: title
+  uid:
+    -
+      plugin: d7_user_lookup
+      source: node_uid
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid:
+    -
+      plugin: d7_user_lookup
+      source: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  body:
+    -
+      plugin: get
+      source: body
+    -
+      plugin: str_replace
+      regex: true
+      search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
+      replace: ''
+  body/0/format:
+    -
+      plugin: static_map
+      bypass: true
+      source: body/0/format
+      map:
+        filtered_html: basic_html
+        filtered_html_with_no_images: basic_html
+        filtered_html_with_templates: basic_html
+        filtered_html_with_tokens: basic_html
+        html_for_admins: full_html
+        paste_format: plain_text
+        plain_text: plain_text
+destination:
+  plugin: 'entity:node'
+  default_bundle: book
+migration_dependencies:
+  required:
+    - users

--- a/config/sync/migrate_plus.migration_group.migrate_group_book.yml
+++ b/config/sync/migrate_plus.migration_group.migrate_group_book.yml
@@ -1,0 +1,12 @@
+uuid: 5c102326-3fe9-414f-889e-31445645fa16
+langcode: en
+status: true
+dependencies: {  }
+id: migrate_group_book
+label: 'Departmental sites - Book'
+description: 'Migrate book'
+source_type: 'Drupal 7'
+module: null
+shared_configuration:
+  source:
+    key: drupal7db

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -55,7 +55,7 @@ then
     $DRUSH migrate:import d7_file_media_document --force --limit=10000
   done
 
-  for type in topic subtopic actions application article consultation contact easychart gallery heritage_site infogram landing_page link page profile protected_area ual
+  for type in topic subtopic actions application article collection consultation contact easychart gallery heritage_site infogram landing_page link page profile protected_area ual
   do
     echo "Migrate D7 ${type} nodes"
     $DRUSH migrate:import node_$type --force
@@ -73,6 +73,9 @@ then
   do
     $DRUSH migrate:import node_news --force --limit=10000
   done
+
+  echo "Migrate book config"
+  $DRUSH migrate:import dept_book --force
 
   echo "Migrating URL aliases and redirects"
   $DRUSH migrate:import url_aliases_nodes --force

--- a/web/modules/custom/dept_migrate/config/install/migrate_plus.migration.dept_book.yml
+++ b/web/modules/custom/dept_migrate/config/install/migrate_plus.migration.dept_book.yml
@@ -1,0 +1,26 @@
+id: dept_book
+label: 'Departmental books'
+migration_group: migrate_group_book
+migration_tags:
+  - dept_sites
+source:
+  plugin: book
+process:
+  nid:
+    - plugin: d7_node_lookup
+      source: nid
+  book/bid:
+    - plugin: d7_node_lookup
+      source: bid
+  book/weight:
+    - plugin: get
+      source: weight
+  book/pid:
+    - plugin: migration_lookup
+      migration: dept_book
+destination:
+  plugin: book
+migration_dependencies:
+  required:
+    - user
+    - node_collection

--- a/web/modules/custom/dept_migrate/config/install/migrate_plus.migration_group.migrate_group_book.yml
+++ b/web/modules/custom/dept_migrate/config/install/migrate_plus.migration_group.migrate_group_book.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: migrate_group_book
+label: 'Departmental sites - Book'
+description: 'Migrate book'
+source_type: 'Drupal 7'
+module: null
+shared_configuration:
+  source:
+    key: drupal7db

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_collection.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_collection.yml
@@ -1,0 +1,63 @@
+id: node_collection
+label: 'Collection content type nodes'
+status: true
+dependencies: {  }
+migration_group: migrate_group_nodes
+migration_tags:
+  - dept_sites
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: alterFieldInstanceMigration
+source:
+  plugin: d7_dept_node
+  node_type: book
+  track_changes: true
+process:
+  langcode:
+    -
+      plugin: default_value
+      source: language
+      default_value: en
+  title: title
+  uid:
+    -
+      plugin: d7_user_lookup
+      source: node_uid
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid:
+    -
+      plugin: d7_user_lookup
+      source: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  body:
+    -
+      plugin: get
+      source: body
+    -
+      plugin: str_replace
+      regex: true
+      search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
+      replace: ''
+  body/0/format:
+    -
+      plugin: static_map
+      bypass: true
+      source: body/0/format
+      map:
+        filtered_html: basic_html
+        filtered_html_with_no_images: basic_html
+        filtered_html_with_templates: basic_html
+        filtered_html_with_tokens: basic_html
+        html_for_admins: full_html
+        paste_format: plain_text
+        plain_text: plain_text
+destination:
+  plugin: 'entity:node'
+  default_bundle: book
+migration_dependencies:
+  required:
+    - users

--- a/web/modules/custom/dept_migrate/src/MigrateUuidLookupManager.php
+++ b/web/modules/custom/dept_migrate/src/MigrateUuidLookupManager.php
@@ -163,6 +163,12 @@ class MigrateUuidLookupManager {
         }
 
         $node = $this->entityTypeManager->getStorage('node')->load($row->destid1);
+
+        if (!$node instanceof NodeInterface) {
+          $this->logger->error('No node found with id ' . $row->destid1);
+          continue;
+        }
+
         $map[$d7nid]['nid'] = $node->id();
         $map[$d7nid]['uuid'] = $node->uuid();
         $map[$d7nid]['title'] = $node->label();


### PR DESCRIPTION
Importing books and config relies on:

* Book module being enabled
* Collection nodes being imported *first* (they act as the book entity/housing themselves)
* Book migration happening which links together existing nodes (a variety of content types) and allocating them to the Collection nodes from before.

Migrations still suffer from occasional instances where a D7 or D9 node can't be found, for whatever reason. We'll be looking to improve visibility of that in a later feature.