### PR TITLE
Add MediaWysiwyg process plugin and add to node body process pipeline

### DIFF
--- a/config/sync/migrate_plus.migration.node_actions.yml
+++ b/config/sync/migrate_plus.migration.node_actions.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 439a25a3-109d-4158-b148-dc9eb6685df6
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_actions
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Actions content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: actions
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,15 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_outcomes:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_outcomes
+      process:
+        target_id: tid
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: actions
 migration_dependencies:
   required:
     - users

--- a/config/sync/migrate_plus.migration.node_application.yml
+++ b/config/sync/migrate_plus.migration.node_application.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: b2b7ec89-594b-4596-b0b6-49a987639f84
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_application
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Application content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: application
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,30 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_summary: field_summary
+  field_global_topics:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_global_topics
+      process:
+        target_id: tid
+  field_additional_info: field_additional_info
+  field_site_topics: field_site_topics
+  field_site_subtopics: field_site_subtopics
+  field_link:
+    -
+      plugin: sub_process
+      source: field_link
+      process:
+        uri: value
+        title: title
+        options: attributes
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: application
 migration_dependencies:
   required:
     - users
+    - node_subtopic
+    - node_topic
+    - d7_taxonomy_term_global_topics

--- a/config/sync/migrate_plus.migration.node_article.yml
+++ b/config/sync/migrate_plus.migration.node_article.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 705b2c28-417c-432d-9521-a69eadb6bb6d
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_article
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Article nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: article
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,22 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_summary: field_summary
+  field_global_topics:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_global_topics
+      process:
+        target_id: tid
+  field_site_topics: field_site_topics
+  field_site_subtopics: field_site_subtopics
+  field_original_domain: field_original_domain
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: article
 migration_dependencies:
   required:
     - users
+    - node_subtopic
+    - node_topic
+    - d7_taxonomy_term_global_topics

--- a/config/sync/migrate_plus.migration.node_consultation.yml
+++ b/config/sync/migrate_plus.migration.node_consultation.yml
@@ -1,4 +1,4 @@
-uuid: 27a63053-b31f-48d7-95c5-90cb0b7eca7a
+uuid: e493f192-c75d-4f50-b8f1-99d6c68ab516
 langcode: en
 status: true
 dependencies: {  }
@@ -40,6 +40,8 @@ process:
     -
       plugin: get
       source: body
+    -
+      plugin: media_wysiwyg_filter
     -
       plugin: str_replace
       regex: true
@@ -127,3 +129,6 @@ destination:
 migration_dependencies:
   required:
     - users
+    - node_subtopic
+    - node_topic
+    - d7_taxonomy_term_global_topics

--- a/config/sync/migrate_plus.migration.node_contact.yml
+++ b/config/sync/migrate_plus.migration.node_contact.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: b0ba6ac6-f4bc-44e6-a491-0abe60cb741b
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_contact
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Contact content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: contact
   track_changes: true
 process:
   langcode:
@@ -27,7 +27,7 @@ process:
       source: node_uid
   status: status
   created: created
-  changed: changed
+  changed: timestamp
   promote: promote
   sticky: sticky
   revision_uid:
@@ -60,13 +60,15 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
-    -
-      plugin: get
-      source: easychart
+  field_map: field_map
+  field_site_subtopics: field_site_subtopics
+  field_site_topics: field_site_topics
+  field_original_domain: field_original_domain
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: contact
 migration_dependencies:
   required:
     - users
+    - node_subtopic
+    - node_topic

--- a/config/sync/migrate_plus.migration.node_gallery.yml
+++ b/config/sync/migrate_plus.migration.node_gallery.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: a6272725-d0ed-4e7e-b1c3-30867b47c8f1
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_gallery
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Gallery content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: gallery
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,33 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_summary: field_summary
+  field_teaser: field_teaser
+  field_gallery_images:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_gallery_images
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_global_topics:
+    -
+      plugin: sub_process
+      source: field_global_topics
+      process:
+        target_id: tid
+  field_site_topics: field_site_topics
+  field_site_subtopics: field_site_subtopics
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: gallery
 migration_dependencies:
   required:
     - users
+    - d7_file_media_image
+    - d7_file_media_video
+    - node_subtopic
+    - node_topic
+    - d7_taxonomy_term_global_topics

--- a/config/sync/migrate_plus.migration.node_heritage_site.yml
+++ b/config/sync/migrate_plus.migration.node_heritage_site.yml
@@ -1,20 +1,18 @@
-uuid: f77c27de-11e7-4d68-a286-5bb2b44c3dad
+uuid: 3db3ad61-08f7-4b7f-bd45-fb0b3a2443a8
 langcode: en
 status: true
 dependencies: {  }
-id: node_publication
+id: node_heritage_site
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Publication content type nodes'
+label: 'Heritage site nodes'
 source:
   plugin: d7_dept_node
-  node_type:
-    - publication
-    - secure_publication
+  node_type: heritage_site
   track_changes: true
 process:
   langcode:
@@ -62,70 +60,63 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  field_summary: field_summary
-  field_publication_type: field_publication_type
-  field_last_updated:
+  field_address_line_1: field_address_line_1
+  field_address_line_2: field_address_line_2
+  field_town: field_town
+  field_county: field_county
+  field_postcode: field_postcode
+  field_sm_number: field_sm_number
+  field_website:
     -
       plugin: sub_process
-      source: field_last_updated
+      source: field_website
       process:
-        value:
-          plugin: format_date
-          source: value
-          from_format: 'Y-m-d H:i:s'
-          to_format: 'Y-m-d\TH:i:s'
-  field_global_topics:
+        uri: value
+        title: title
+        options: attributes
+  field_phone: field_phone
+  field_email:
     -
       plugin: sub_process
-      source: field_global_topics
+      source: field_email
       process:
-        target_id: tid
-  field_site_subtopics:
+        value: email
+  field_grid_reference: field_grid_reference
+  field_historic_map_viewer_link:
     -
       plugin: sub_process
-      source: field_site_subtopics
+      source: field_historic_map_viewer_link
       process:
-        target_id: tid
-  field_published_date:
+        uri: value
+        title: title
+        options: attributes
+  field_nismr_link:
     -
       plugin: sub_process
-      source: field_published_date
+      source: field_nismr_link
       process:
-        value:
-          plugin: format_date
-          from_format: 'Y-m-d H:i:s'
-          to_format: Y-m-d
-          source: value
-  field_publication_files:
-    plugin: sub_process
-    source: field_attachment
-    process:
-      target_id:
-        -
-          plugin: d7_file_lookup
-          source: fid
-          entity_type: media
-        -
-          plugin: default_value
-          default_value: 97431
-  field_publication_secure_files:
-    plugin: sub_process
-    source: field_secure_attachment
-    process:
-      target_id:
-        plugin: d7_file_lookup
-        source: fid
-  field_external_publication:
-    plugin: sub_process
-    source: field_external_publication
-    process:
-      uri: url
-      title: title
-      attributes: attributes
+        uri: value
+        title: title
+        options: attributes
+  field_open_to_the_public: field_open_to_the_public
+  field_photo:
+    -
+      plugin: sub_process
+      source: field_photo
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_site_subtopics: field_site_subtopics
+  field_site_topics: field_site_topics
+  field_map: field_map
 destination:
   plugin: 'entity:node'
-  default_bundle: publication
+  default_bundle: heritage_site
 migration_dependencies:
   required:
     - users
-    - d7_file_media_document
+    - d7_file_media_image
+    - node_subtopic
+    - node_topic

--- a/config/sync/migrate_plus.migration.node_infogram.yml
+++ b/config/sync/migrate_plus.migration.node_infogram.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 79254696-6884-46ac-88de-bf5216eebf20
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_infogram
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Infogram content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: infogram
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,29 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_chart_taxonomy:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_chart_taxonomy
+      process:
+        target_id: tid
+  field_chart_type:
+    -
+      plugin: sub_process
+      source: field_chart_type
+      process:
+        target_id: tid
+  field_indicators:
+    -
+      plugin: sub_process
+      source: field_indicators
+      process:
+        target_id: tid
+  field_infogram: field_infogram
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: infogram
 migration_dependencies:
   required:
     - users
+    - d7_taxonomy_term_chart_type

--- a/config/sync/migrate_plus.migration.node_landing_page.yml
+++ b/config/sync/migrate_plus.migration.node_landing_page.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 56eef071-743c-4bd1-acb0-7748af4dfc58
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_landing_page
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Landing page nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: landing_page
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,38 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_banner_image:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_banner_image
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_banner_image_overlay:
+    -
+      plugin: sub_process
+      source: field_banner_image_overlay
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_enable_title: field_enable_title
+  field_summary: field_summary
+  field_teaser: field_teaser
+  field_site_subtopics: field_site_subtopics
+  field_site_topics: field_site_topics
+  field_facebook_user: field_facebook_user
+  field_tweet_count: field_tweet_count
+  field_twitter_user: field_twitter_user
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: landing_page
 migration_dependencies:
   required:
     - users
+    - d7_file_media_image
+    - node_subtopic
+    - node_topic

--- a/config/sync/migrate_plus.migration.node_link.yml
+++ b/config/sync/migrate_plus.migration.node_link.yml
@@ -1,18 +1,18 @@
-uuid: 8e702165-1169-4059-8bf6-554cbe11f236
+uuid: e67c0c4e-28af-47eb-ac3d-cc9e67152e5a
 langcode: en
 status: true
 dependencies: {  }
-id: node_collection
+id: node_link
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Collection content type nodes'
+label: 'Link nodes'
 source:
   plugin: d7_dept_node
-  node_type: book
+  node_type: link
   track_changes: true
 process:
   langcode:
@@ -36,33 +36,15 @@ process:
       source: revision_uid
   revision_log: log
   revision_timestamp: timestamp
-  body:
+  field_file_language: field_file_language
+  field_link_type: field_link_type
+  field_link_url:
     -
-      plugin: get
-      source: body
-    -
-      plugin: media_wysiwyg_filter
-    -
-      plugin: str_replace
-      regex: true
-      search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
-      replace: ''
-  body/0/format:
-    -
-      plugin: static_map
-      bypass: true
-      source: body/0/format
-      map:
-        filtered_html: basic_html
-        filtered_html_with_no_images: basic_html
-        filtered_html_with_templates: basic_html
-        filtered_html_with_tokens: basic_html
-        html_for_admins: full_html
-        paste_format: plain_text
-        plain_text: plain_text
+      plugin: field_link
+      source: field_link_url
 destination:
   plugin: 'entity:node'
-  default_bundle: book
+  default_bundle: link
 migration_dependencies:
   required:
     - users

--- a/config/sync/migrate_plus.migration.node_news.yml
+++ b/config/sync/migrate_plus.migration.node_news.yml
@@ -1,4 +1,4 @@
-uuid: 54a639d1-99be-4766-8cb1-01be118f7274
+uuid: 55fa5947-fb43-4b08-a79e-bd923cb31add
 langcode: en
 status: true
 dependencies: {  }
@@ -11,7 +11,7 @@ migration_tags:
 migration_group: migrate_group_nodes
 label: 'News content type nodes'
 source:
-  plugin: d7_node_uuid
+  plugin: d7_dept_node
   node_type: news
   track_changes: true
 process:
@@ -40,6 +40,8 @@ process:
     -
       plugin: get
       source: body
+    -
+      plugin: media_wysiwyg_filter
     -
       plugin: str_replace
       regex: true
@@ -108,3 +110,4 @@ migration_dependencies:
     - users
     - d7_file_media_image
     - d7_file_media_video
+    - d7_taxonomy_term_global_topics

--- a/config/sync/migrate_plus.migration.node_page.yml
+++ b/config/sync/migrate_plus.migration.node_page.yml
@@ -1,25 +1,25 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 17b0c908-61ac-45b8-a938-b5ec9d92fbb0
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_page
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Page nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: page
   track_changes: true
 process:
   langcode:
     -
       plugin: default_value
       source: language
-      default_value: en
+      default_value: und
   title: title
   uid:
     -
@@ -60,13 +60,10 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
-    -
-      plugin: get
-      source: easychart
+  field_original_domain: field_original_domain
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: page
 migration_dependencies:
   required:
     - users

--- a/config/sync/migrate_plus.migration.node_profile.yml
+++ b/config/sync/migrate_plus.migration.node_profile.yml
@@ -1,25 +1,25 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 4b081cff-ca65-400a-9c51-d7bb71902970
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_profile
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Profile nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: profile
   track_changes: true
 process:
   langcode:
     -
       plugin: default_value
       source: language
-      default_value: en
+      default_value: und
   title: title
   uid:
     -
@@ -60,13 +60,22 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_photo:
     -
-      plugin: get
-      source: easychart
+      plugin: sub_process
+      source: field_photo
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_summary: field_summary
+  field_department: field_department
+  field_original_domain: field_original_domain
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: profile
 migration_dependencies:
   required:
     - users
+    - d7_file_media_image

--- a/config/sync/migrate_plus.migration.node_protected_area.yml
+++ b/config/sync/migrate_plus.migration.node_protected_area.yml
@@ -1,25 +1,25 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 5fb5851e-7438-49c8-83f4-f538f0b0b576
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_protected_area
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Protected area nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: protected_area
   track_changes: true
 process:
   langcode:
     -
       plugin: default_value
       source: language
-      default_value: en
+      default_value: und
   title: title
   uid:
     -
@@ -60,13 +60,17 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
-    -
-      plugin: get
-      source: easychart
+  field_council: field_council
+  field_county: field_county
+  field_protected_area_feature: field_protected_area_feature
+  field_site_subtopics: field_site_subtopics
+  field_site_topics: field_site_topics
+  field_protected_area_type: field_protected_area_type
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: protected_area
 migration_dependencies:
   required:
     - users
+    - node_subtopic
+    - node_topic

--- a/config/sync/migrate_plus.migration.node_subtopic.yml
+++ b/config/sync/migrate_plus.migration.node_subtopic.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: 57de9dbb-84c6-4b2b-a4df-64ed7388f12c
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_subtopic
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Subtopic content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: subtopic
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,35 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_parent_subtopic:
     -
       plugin: get
-      source: easychart
+      source: field_parent_subtopic
+  field_parent_topic:
+    -
+      plugin: get
+      source: field_parent_topic
+  field_summary:
+    -
+      plugin: get
+      source: field_summary
+  field_banner_image:
+    -
+      plugin: sub_process
+      source: field_banner_image
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_link:
+    -
+      plugin: field_link
+      source: field_link
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: subtopic
 migration_dependencies:
   required:
     - users
+    - d7_file_media_image

--- a/config/sync/migrate_plus.migration.node_topic.yml
+++ b/config/sync/migrate_plus.migration.node_topic.yml
@@ -1,18 +1,18 @@
-uuid: 9fc375be-626c-4a21-8b30-e393d55ad84a
+uuid: cf1087b5-0688-4bc3-a202-57f4dd4c41a3
 langcode: en
 status: true
 dependencies: {  }
-id: node_easychart
+id: node_topic
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
 cck_plugin_method: null
 migration_tags:
   - dept_sites
 migration_group: migrate_group_nodes
-label: 'Easychart content type nodes'
+label: 'Topic content type nodes'
 source:
   plugin: d7_dept_node
-  node_type: easychart
+  node_type: topic
   track_changes: true
 process:
   langcode:
@@ -60,13 +60,23 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  easychart:
+  field_summary:
     -
       plugin: get
-      source: easychart
+      source: field_summary
+  field_photo:
+    -
+      plugin: sub_process
+      source: field_photo
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
 destination:
   plugin: 'entity:node'
-  default_bundle: easychart
+  default_bundle: topic
 migration_dependencies:
   required:
     - users
+    - d7_file_media_image

--- a/config/sync/migrate_plus.migration.node_ual.yml
+++ b/config/sync/migrate_plus.migration.node_ual.yml
@@ -1,0 +1,74 @@
+uuid: 94265be2-cd1f-4ba8-911e-21780cf7f7a0
+langcode: en
+status: true
+dependencies: {  }
+id: node_ual
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: alterFieldInstanceMigration
+cck_plugin_method: null
+migration_tags:
+  - dept_sites
+migration_group: migrate_group_nodes
+label: 'Unlawfully at large nodes'
+source:
+  plugin: d7_dept_node
+  node_type: ual
+  track_changes: true
+process:
+  langcode:
+    -
+      plugin: default_value
+      source: language
+      default_value: und
+  title: title
+  uid:
+    -
+      plugin: d7_user_lookup
+      source: node_uid
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+  revision_uid:
+    -
+      plugin: d7_user_lookup
+      source: revision_uid
+  revision_log: log
+  revision_timestamp: timestamp
+  field_age: field_age
+  field_description: field_description
+  field_distinguishing_marks: field_distinguishing_marks
+  field_eye_colour: field_eye_colour
+  field_hair_colour: field_hair_colour
+  field_offence: field_offence
+  field_photo:
+    -
+      plugin: sub_process
+      source: field_photo
+      process:
+        target_id:
+          -
+            plugin: d7_file_lookup
+            source: fid
+  field_prison: field_prison
+  field_release_type: field_release_type
+  field_ual_from:
+    -
+      plugin: sub_process
+      source: field_ual_from
+      process:
+        value:
+          plugin: format_date
+          from_format: 'Y-m-d H:i:s'
+          to_format: Y-m-d
+          source: value
+  field_original_domain: field_original_domain
+destination:
+  plugin: 'entity:node'
+  default_bundle: ual
+migration_dependencies:
+  required:
+    - users
+    - d7_file_media_image
+    - null

--- a/config/sync/migrate_plus.migration_group.migrate_group_dept_book.yml
+++ b/config/sync/migrate_plus.migration_group.migrate_group_dept_book.yml
@@ -1,0 +1,10 @@
+uuid: c8028c16-fcf7-41cf-87aa-1d6f73bb2e75
+langcode: en
+status: true
+dependencies: {  }
+id: migrate_group_dept_book
+label: migrate_group_dept_book
+description: ''
+source_type: null
+module: null
+shared_configuration: null

--- a/config/sync/migrate_plus.migration_group.migrate_group_redirects.yml
+++ b/config/sync/migrate_plus.migration_group.migrate_group_redirects.yml
@@ -1,10 +1,12 @@
-uuid: 0506e26c-25e8-49d1-86ca-83493da508f0
+uuid: 63cd7239-3931-44b2-8c14-66b7a229a083
 langcode: en
 status: true
 dependencies: {  }
 id: migrate_group_redirects
-label: migrate_group_redirects
-description: ''
-source_type: null
+label: 'Departmental sites - Redirects'
+description: 'Migrate redirects'
+source_type: 'Drupal 7'
 module: null
-shared_configuration: null
+shared_configuration:
+  source:
+    key: drupal7db

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_actions.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_actions.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_application.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_application.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_article.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_article.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_collection.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_collection.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_consultation.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_consultation.yml
@@ -33,6 +33,7 @@ process:
   body:
     - plugin: get
       source: body
+    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_easychart.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_easychart.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_gallery.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_gallery.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_infogram.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_infogram.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_news.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_news.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_page.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_profile.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_profile.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_protected_area.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_protected_area.yml
@@ -34,11 +34,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -35,6 +35,7 @@ process:
   body:
     - plugin: get
       source: body
+    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_subtopic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_subtopic.yml
@@ -33,11 +33,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_topic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_topic.yml
@@ -33,11 +33,10 @@ process:
   revision_log: log
   revision_timestamp: timestamp
   body:
-    -
-      plugin: get
+    - plugin: get
       source: body
-    -
-      plugin: str_replace
+    - plugin: media_wysiwyg_filter
+    - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''

--- a/web/modules/custom/dept_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
+++ b/web/modules/custom/dept_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Drupal\dept_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dept_migrate\MigrateUuidLookupManager;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Serializer\Encoder\JsonDecode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Drupal\Core\Database\Connection;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+
+/**
+ * Processes [[{"type":"media","fid":"1234",...}]] tokens in content.
+ *
+ * These style tokens come from media_wysiwyg module. The regex it uses to match
+ * them for reference is:
+ *
+ * /\[\[.+?"type":"media".+?\]\]/s
+ *
+ * @code
+ * # From this
+ * [[{"type":"media","fid":"1234",...}]]
+ *
+ * # To this
+ * <drupal-media
+ *   data-align="center"
+ *   data-entity-type="media"
+ *   data-entity-uuid="2fdf6f0c-ac41-4d24-a491-06417a2a6c80"
+ *   data-view-mode="landscape_float">
+ * </drupal-media>
+ * @endcode
+ *
+ * Usage:
+ *
+ * @endcode
+ * process:
+ *   bar:
+ *     plugin: media_wysiwyg_filter
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "media_wysiwyg_filter"
+ * )
+ */
+class MediaWysiwygFilter extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The Drupal 8 database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connDb;
+
+  /**
+   * The migration database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connMigrate;
+
+  /**
+   * The lookup manager service.
+   *
+   * @var \Drupal\dept_migrate\MigrateUuidLookupManager
+   */
+  protected $lookupManager;
+
+  /**
+   * Constructs a UpdateFileToDocument process plugin instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param array $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   Database connection.
+   * @param \Drupal\dept_migrate\MigrateUuidLookupManager $lookup_manager
+   *   Lookup manager service object.
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, Connection $connection, MigrateUuidLookupManager $lookup_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->connDb = $connection;
+    $this->connMigrate = Database::getConnection('default', 'migrate');
+    $this->lookupManager = $lookup_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('database'),
+      $container->get('dept_migrate.migrate_uuid_lookup_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $pattern = '/\[\[(?<tag_info>.+?"type":"media".+?)\]\]/s';
+
+    $messenger = $this->messenger();
+    $nid = $row->getSourceProperty('nid');
+    // Convert from D7 to D9 node id.
+    $lookup = $this->lookupManager->lookupBySourceNodeId([$nid]);
+    $nid = $lookup['nid'];
+
+    $value['value'] = preg_replace_callback($pattern, function ($matches) use ($messenger, $nid) {
+      $decoder = new JsonDecode(TRUE);
+
+      try {
+        // Extract the D7 embedded media data.
+        $tag_info = $decoder->decode($matches['tag_info'], JsonEncoder::FORMAT);
+        $fid = $tag_info['fid'];
+        $file_lookup = $this->lookupManager->lookupBySourceFileId([$fid]);
+        $fidd9 = reset($file_lookup)['id'];
+        $media_lookup = $this->lookupManager->lookupMediaBySourceFileId([$fid]);
+        $midd9 = reset($media_lookup)['id'];
+
+        // Lookup the Migration DB and check if we are referencing an embedded
+        // or file asset.
+        $query = $this->connMigrate->select('file_managed', 'f');
+        $query->condition('f.fid', $tag_info['fid'], '=');
+        $query->fields('f', ['filemime']);
+        $query->range(0, 1);
+        $media = $query->execute()->fetchAssoc();
+
+        if ($media['filemime'] === 'video/oembed') {
+          // Search for oembed/remote media which doesn't have a
+          // managed file entry.
+          $query = $this->connDb->select('media', 'm');
+          $query->condition('m.mid', $midd9, '=');
+          $query->fields('m', ['uuid']);
+          $query->addField('o', 'bundle');
+          $query->join('media__field_media_oembed_video', 'o', 'o.entity_id = m.mid');
+          $query->range(0, 1);
+          $oembed = $query->execute()->fetchAssoc();
+
+          if ($oembed['bundle'] === 'remote_video') {
+            $replacement_template = <<<'TEMPLATE'
+<drupal-media
+data-align="center"
+data-entity-type="media"
+data-entity-uuid="%s">
+</drupal-media>
+TEMPLATE;
+          }
+          return sprintf($replacement_template, $oembed['uuid']);
+        }
+
+        // Ensure we have a managed file for the embedded asset.
+        $query = $this->connDb->select('file_managed', 'f');
+        $query->condition('f.fid', $fidd9, '=');
+        $query->fields('f', ['uuid', 'filename', 'filemime', 'uri']);
+        $query->range(0, 1);
+        $file = $query->execute()->fetchAssoc();
+
+        if (!empty($file)) {
+          $tag_info['filemime'] = $file['filemime'];
+
+          $tag_info = array_merge($tag_info, ['fid' => $fidd9]);
+
+          // Determine the media file type to handle.
+          switch (substr($file['filemime'], 0, strpos($file['filemime'], '/'))) {
+            case 'image':
+              return $this->imageMediaEmbed($tag_info);
+
+            case 'audio':
+              $media_type = 'audio_file';
+              return $this->genericMediaEmbed($tag_info, $media_type);
+
+            case 'application':
+              $media_type = 'file';
+              return $this->genericMediaEmbed($tag_info, $media_type);
+
+            default:
+              break;
+          }
+        }
+      }
+      catch (NotEncodableValueException $e) {
+        // There was an error decoding the JSON. Remove code.
+        $messenger->addWarning(sprintf('The following media_wysiwyg token in node %d does not have valid JSON: %s',
+          $nid, $matches[0]));
+        return NULL;
+      }
+      return NULL;
+    }, $value['value']);
+
+    return $value;
+  }
+
+  /**
+   * Creates a generic Drupal Media element.
+   *
+   * @param array $tag_info
+   *   D7 embedded media json array.
+   * @param string $media_type
+   *   The D8 media type table/field to query.
+   *
+   * @return string
+   *   A drupal-media element.
+   */
+  protected function genericMediaEmbed(array $tag_info, string $media_type) {
+
+    $replacement_template = <<<'TEMPLATE'
+<drupal-media
+data-align="center"
+data-entity-type="media"
+data-entity-uuid="%s">
+</drupal-media>
+TEMPLATE;
+
+    // Extract the base media entity uuid.
+    $query = $this->connDb->select('media', 'm');
+    $query->fields('m', ['uuid']);
+    $query->addField('i', 'entity_id');
+    $query->join("media__field_media_" . $media_type, 'i', 'i.entity_id = m.mid');
+    $query->condition('field_media_' . $media_type . '_target_id', $tag_info['fid'], '=');
+    $query->range(0, 1);
+    $media = $query->execute()->fetchAssoc();
+
+    // Update drupal-media template values.
+    return sprintf($replacement_template, $media['uuid']);
+  }
+
+  /**
+   * Creates a Drupal Media image element.
+   *
+   * @param array $tag_info
+   *   D7 embedded media json array.
+   *
+   * @return string
+   *   A drupal-media element.
+   */
+  protected function imageMediaEmbed(array $tag_info) {
+    $replacement_template = <<<'TEMPLATE'
+<drupal-media
+data-align="center"
+data-entity-type="media"
+data-entity-uuid="%s"
+data-view-mode="%s">
+</drupal-media>
+TEMPLATE;
+
+    // Extract the base media entity uuid.
+    $query = $this->connDb->select('media', 'm');
+    $query->fields('m', ['uuid']);
+    $query->addField('i', 'entity_id');
+    $query->addField('i', 'field_media_image_width', 'width');
+    $query->addField('i', 'field_media_image_height', 'height');
+    $query->join('media__field_media_image', 'i', 'i.entity_id = m.mid');
+    $query->condition('i.field_media_image_target_id', $tag_info['fid'], '=');
+    $query->range(0, 1);
+    $media = $query->execute()->fetchAssoc();
+
+    // Updated image formats when converting from D7.
+    // The first style for each orientation will be used as a default if no
+    // value if found in the tag.
+    $style_map = [
+      'landscape' => [
+        'inline' => 'landscape_float',
+        'inline_expandable' => 'landscape_float_xp',
+        'inline_xl' => 'landscape_full_xp',
+      ],
+      'portrait' => [
+        'inline' => 'portrait_float',
+        'inline_expandable' => 'portrait_float_xp',
+        'inline_xl' => 'portrait_full',
+      ],
+    ];
+
+    // Select the appropriate display orientation based on the
+    // image dimensions.
+    $orientation = ($media['width'] >= $media['height']) ? 'landscape' : 'portrait';
+
+    // Set a default image style.
+    $image_style = 'article_full';
+
+    // Assign the image style to the embedded image if we can extract it from
+    // the original image tag.
+    if (isset($tag_info['attributes']['data-picture-mapping']) || array_key_exists('data-picture-mapping', $tag_info['attributes'])) {
+      if (array_key_exists($tag_info['attributes']['data-picture-mapping'], $style_map[$orientation])) {
+        $image_style = $style_map[$orientation][$tag_info['attributes']['data-picture-mapping']];
+      }
+    }
+
+    // Update drupal-media template values.
+    return sprintf($replacement_template, $media['uuid'], $image_style);
+  }
+
+}


### PR DESCRIPTION
Something of a 'config bomb' but the gist of it is:

* Adds a migrate process plugin to convert the D7 media embed tokens to valid D9 versions, with file ids rewritten to the correct D9 items.
* Config to support this across all node body fields