### PR TITLE
Add env var for solr host/port on psh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
       - image: circleci/php:7.4.15-apache-browsers
     environment:
       EDGE_BUILD_BRANCH: "DEPT-edge"
+      PLATFORM_SOLR_HOST: "solr.internal:8080"
     steps:
       - hosts_keyscan
       - checkout_code


### PR DESCRIPTION
Don't perceive this to be a service disclosure risk, as that information is easily derived from PSH public docs around Solr service defaults for Drupal projects and there's little that can be done to access this service from outside the cluster without an authenticated SSH tunnel. Can also store this in Circle CI but the value is then obfuscated even from admin view which takes longer for future debugging.