### PR TITLE
Double solr disk size, enlarge main db from excess in d7 db

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -32,7 +32,7 @@ relationships:
   drupal7db: 'drupal7db:admin'
 
 # The size of the persistent disk of the application (in MB).
-disk: 100000
+disk: 99500
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -7,7 +7,7 @@ db:
   # the CLI will return an error.
   type: mariadb:10.4
   # The disk attribute is the size of the persistent disk (in MB) allocated to the service.
-  disk: 4096
+  disk: 10000
   configuration:
     schemas:
       - main
@@ -19,7 +19,7 @@ db:
 
 drupal7db:
   type: mariadb:10.4
-  disk: 16384
+  disk: 10000
   configuration:
     schemas:
       - main
@@ -32,7 +32,7 @@ drupal7db:
 # Fudging the service name forces a full rebuild with any new config.
 solr:
   type: solr:7.7
-  disk: 256
+  disk: 512
   configuration:
     cores:
       default:


### PR DESCRIPTION
- Metrics show D7 db size is only at 30% usage - likely due to trimming of unwanted cache tables etc.
- Increase Solr disk space size as we're filling it with much more content now.
- Increase D9 db disk size to accommodate extra content (by recycling the excess from the D7 db service we weren't using)