### PR TITLE
Catch stdout and stderr for output to tee command

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -157,7 +157,7 @@ crons:
     cmd: 'migrate-scripts/sync-private-files.sh $D7_PROJECT_ID $D7_PROJECT_ENV'
   migrate:
     spec: '30 2 * * *'
-    cmd: 'migrate-scripts/migrate.sh | tee /app/imports/last-migrate-output.txt'
+    cmd: 'migrate-scripts/migrate.sh 2>&1 | tee /app/imports/last-migrate-output.txt'
   drupal:
     spec: '*/15 * * * *'
     cmd: 'vendor/bin/drush cron'


### PR DESCRIPTION
Without this, a good bit of detail is lost as drush does some curious things with different TTY data streams.