### PR TITLE
DEPT 62: RSS feeds for publications by topics/subtopics

### DIFF
--- a/config/sync/field.field.node.application.field_site_topics.yml
+++ b/config/sync/field.field.node.application.field_site_topics.yml
@@ -10,7 +10,7 @@ field_name: field_site_topics
 entity_type: node
 bundle: application
 label: 'Site topics'
-description: 'hoose relevant site topic(s) for this application. Hold down Ctrl to choose multiple site topics.'
+description: 'Choose relevant site topic(s) for this application. Hold down Ctrl to choose multiple site topics.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/group.role.department_site-anonymous.yml
+++ b/config/sync/group.role.department_site-anonymous.yml
@@ -12,6 +12,7 @@ audience: anonymous
 group_type: department_site
 permissions_ui: true
 permissions:
+  - 'view group'
   - 'view group_media:audio entity'
   - 'view group_media:document entity'
   - 'view group_media:image entity'

--- a/config/sync/migrate_plus.migration.node_application.yml
+++ b/config/sync/migrate_plus.migration.node_application.yml
@@ -1,4 +1,4 @@
-uuid: 35fd6c41-d030-455e-bf95-746219f1c501
+uuid: bb04d6b6-0734-4c14-8452-6def28fa6908
 langcode: en
 status: true
 dependencies: {  }
@@ -79,8 +79,24 @@ process:
       process:
         target_id: tid
   field_additional_info: field_additional_info
-  field_site_topics: field_site_topics
-  field_site_subtopics: field_site_subtopics
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_link:
     -
       plugin: sub_process

--- a/config/sync/migrate_plus.migration.node_article.yml
+++ b/config/sync/migrate_plus.migration.node_article.yml
@@ -1,4 +1,4 @@
-uuid: 7631698d-6c97-43d3-a097-f1d2a7ce905b
+uuid: 3aa98201-9d39-4b92-a5dd-ea443ab9d4bc
 langcode: en
 status: true
 dependencies: {  }
@@ -81,8 +81,24 @@ process:
       source: field_global_topics
       process:
         target_id: tid
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   moderation_state:
     plugin: static_map
     source: status

--- a/config/sync/migrate_plus.migration.node_consultation.yml
+++ b/config/sync/migrate_plus.migration.node_consultation.yml
@@ -1,4 +1,4 @@
-uuid: f84d0e80-16cf-43ed-b323-68e5a4550e5e
+uuid: 6e4f582b-3ea5-4d10-a81a-78fd3db83133
 langcode: en
 status: true
 dependencies: {  }
@@ -95,8 +95,24 @@ process:
       source: field_global_topics
       process:
         target_id: tid
-  field_site_topics: field_site_topics
-  field_site_subtopics: field_site_subtopics
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_postal: field_postal
   field_published_date:
     -

--- a/config/sync/migrate_plus.migration.node_contact.yml
+++ b/config/sync/migrate_plus.migration.node_contact.yml
@@ -1,4 +1,4 @@
-uuid: b5bd52ee-02ca-42b0-9f6e-763e632cffa0
+uuid: 691af800-906b-429e-9895-f5f73e08371d
 langcode: en
 status: true
 dependencies: {  }
@@ -72,8 +72,24 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_map: field_map
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_original_domain: field_original_domain
 destination:
   plugin: 'entity:node'

--- a/config/sync/migrate_plus.migration.node_gallery.yml
+++ b/config/sync/migrate_plus.migration.node_gallery.yml
@@ -1,4 +1,4 @@
-uuid: 015de61a-c32d-4dea-9b26-b7fe9ac6e3fe
+uuid: 3ef47d7b-52d1-483f-b1e1-3af5bda5d3a0
 langcode: en
 status: true
 dependencies: {  }
@@ -89,8 +89,24 @@ process:
       source: field_global_topics
       process:
         target_id: tid
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
 destination:
   plugin: 'entity:node'
   default_bundle: gallery

--- a/config/sync/migrate_plus.migration.node_heritage_site.yml
+++ b/config/sync/migrate_plus.migration.node_heritage_site.yml
@@ -1,4 +1,4 @@
-uuid: 9f9f36a2-7b1c-424d-9e92-107086229bcd
+uuid: cd16a2b5-07b1-4841-a5a3-53e042a0daab
 langcode: en
 status: true
 dependencies: {  }
@@ -119,8 +119,24 @@ process:
           -
             plugin: d7_file_lookup
             source: fid
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_map: field_map
 destination:
   plugin: 'entity:node'

--- a/config/sync/migrate_plus.migration.node_landing_page.yml
+++ b/config/sync/migrate_plus.migration.node_landing_page.yml
@@ -1,4 +1,4 @@
-uuid: cd75c5da-28a7-49f6-b99e-6e4d16a2a75b
+uuid: 52fdf71c-532f-4ae0-a4ac-d20a881ae558
 langcode: en
 status: true
 dependencies: {  }
@@ -92,8 +92,24 @@ process:
   field_enable_title: field_enable_title
   field_summary: field_summary
   field_teaser: field_teaser
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_facebook_user: field_facebook_user
   field_tweet_count: field_tweet_count
   field_twitter_user: field_twitter_user

--- a/config/sync/migrate_plus.migration.node_protected_area.yml
+++ b/config/sync/migrate_plus.migration.node_protected_area.yml
@@ -1,9 +1,7 @@
-uuid: 9664ed9e-1828-49ac-bf3c-1e056a066154
+uuid: 3841afa2-2c56-4d35-8dfd-d7d402af143f
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: 50m31mUo18_hMVaMjfGp97KxUAD9vLVlg45o8IpKnxA
 id: node_protected_area
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
@@ -73,13 +71,29 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
+  field_protected_area_documents: field_protected_area_documents
   field_council: field_council
   field_county: field_county
   field_protected_area_feature: field_protected_area_feature
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    -
+      plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_protected_area_type: field_protected_area_type
-  field_protected_area_documents: field_protected_area_documents
 destination:
   plugin: 'entity:node'
   default_bundle: protected_area

--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -1,4 +1,4 @@
-uuid: 20d2178b-fea9-48a8-831f-32281a78ba9c
+uuid: 54e14166-1fdf-4e56-9b3b-8ea38b2aa187
 langcode: en
 status: true
 dependencies: {  }
@@ -91,12 +91,24 @@ process:
       source: field_global_topics
       process:
         target_id: tid
+  field_site_topics:
+    -
+      plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_site_subtopics:
     -
       plugin: sub_process
       source: field_site_subtopics
       process:
-        target_id: tid
+        target_id:
+          -
+            plugin: d7_node_lookup
+            source: target_id
   field_published_date:
     -
       plugin: sub_process

--- a/config/sync/views.view.press_releases.yml
+++ b/config/sync/views.view.press_releases.yml
@@ -549,7 +549,7 @@ display:
         type: rss
         options:
           grouping: {  }
-          description: 'RSS feed with the latest press releases from'
+          description: 'RSS feed with the latest press releases'
       row:
         type: rss_fields
         options:

--- a/config/sync/views.view.press_releases.yml
+++ b/config/sync/views.view.press_releases.yml
@@ -1,0 +1,576 @@
+uuid: 1e721064-5796-450a-8ce4-f2fb4a7c5a74
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_published_date
+    - field.storage.node.field_summary
+    - node.type.news
+  module:
+    - datetime
+    - group
+    - node
+    - text
+    - user
+id: press_releases
+label: 'Press Releases'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Latest press releases from'
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_published_date:
+          id: field_published_date
+          table: node__field_published_date
+          field: field_published_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_custom
+          settings:
+            timezone_override: Europe/London
+            date_format: 'D, d M Y H:i:s O'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_summary:
+          id: field_summary
+          table: node__field_summary
+          field: field_summary
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        gid:
+          id: gid
+          table: group_content_field_data
+          field: gid
+          relationship: group_content
+          group_type: group
+          admin_label: ''
+          entity_type: group_content
+          entity_field: gid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '/node/{{ nid }}'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          text: view
+          output_url_as_text: true
+          absolute: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_published_date_value:
+          id: field_published_date_value
+          table: node__field_published_date
+          field: field_published_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            news: news
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+          contextual_filters_or: false
+      relationships:
+        group_content:
+          id: group_content
+          table: node_field_data
+          field: group_content
+          relationship: none
+          group_type: group
+          admin_label: 'Content group content'
+          entity_type: node
+          plugin_id: group_content_to_entity_reverse
+          required: true
+          group_content_plugins:
+            'group_node:news': 'group_node:news'
+            'group_node:actions': '0'
+            'group_node:application': '0'
+            'group_node:article': '0'
+            'group_node:book': '0'
+            'group_node:case_study': '0'
+            'group_node:consultation': '0'
+            'group_node:contact': '0'
+            'group_node:easychart': '0'
+            'group_node:gallery': '0'
+            'group_node:global_page': '0'
+            'group_node:heritage_site': '0'
+            'group_node:infogram': '0'
+            'group_node:landing_page': '0'
+            'group_node:link': '0'
+            'group_node:page': '0'
+            'group_node:profile': '0'
+            'group_node:project': '0'
+            'group_node:protected_area': '0'
+            'group_node:publication': '0'
+            'group_node:subtopic': '0'
+            'group_node:topic': '0'
+            'group_node:ual': '0'
+            'group_node:webform': '0'
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_published_date'
+        - 'config:field.storage.node.field_summary'
+  press_releases_feed:
+    id: press_releases_feed
+    display_title: Feed
+    display_plugin: feed
+    position: 1
+    display_options:
+      style:
+        type: rss
+        options:
+          grouping: {  }
+          description: 'RSS feed with the latest press releases from'
+      row:
+        type: rss_fields
+        options:
+          title_field: title
+          link_field: view_node
+          description_field: field_summary
+          creator_field: gid
+          date_field: field_published_date
+          guid_field_options:
+            guid_field: view_node
+            guid_field_is_permalink: true
+      display_extenders: {  }
+      path: press-releases/rss.xml
+      sitename_title: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_published_date'
+        - 'config:field.storage.node.field_summary'

--- a/config/sync/views.view.publications_feed.yml
+++ b/config/sync/views.view.publications_feed.yml
@@ -1,0 +1,825 @@
+uuid: 074f03f0-65e8-4dfd-83c3-792397da3223
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_published_date
+    - field.storage.node.field_summary
+    - node.type.publication
+    - node.type.subtopic
+    - node.type.topic
+  module:
+    - datetime
+    - group
+    - node
+    - text
+    - user
+id: publications_feed
+label: 'Publications feed'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Latest publications'
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '/node/{{ nid }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_published_date:
+          id: field_published_date
+          table: node__field_published_date
+          field: field_published_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_custom
+          settings:
+            timezone_override: Europe/London
+            date_format: 'D, d M Y H:i:s O'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_summary:
+          id: field_summary
+          table: node__field_summary
+          field: field_summary
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: true
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: view
+          output_url_as_text: true
+          absolute: false
+        id:
+          id: id
+          table: group_content_field_data
+          field: id
+          relationship: group_content
+          group_type: group
+          admin_label: ''
+          entity_type: group_content
+          entity_field: id
+          plugin_id: field
+          label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 50
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_published_date_value:
+          id: field_published_date_value
+          table: node__field_published_date
+          field: field_published_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        field_site_subtopics_target_id:
+          id: field_site_subtopics_target_id
+          table: node__field_site_subtopics
+          field: field_site_subtopics_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            publication: publication
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        gid:
+          id: gid
+          table: group_content_field_data
+          field: gid
+          relationship: group_content
+          group_type: group
+          admin_label: 'Group ID. NB: dynamically set in dept_node_views_query_alter()'
+          entity_type: group_content
+          entity_field: gid
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+          contextual_filters_or: false
+      relationships:
+        group_content:
+          id: group_content
+          table: node_field_data
+          field: group_content
+          relationship: none
+          group_type: group
+          admin_label: 'Content group content'
+          entity_type: node
+          plugin_id: group_content_to_entity_reverse
+          required: true
+          group_content_plugins:
+            'group_node:publication': 'group_node:publication'
+            'group_node:actions': '0'
+            'group_node:application': '0'
+            'group_node:article': '0'
+            'group_node:book': '0'
+            'group_node:case_study': '0'
+            'group_node:consultation': '0'
+            'group_node:contact': '0'
+            'group_node:easychart': '0'
+            'group_node:gallery': '0'
+            'group_node:global_page': '0'
+            'group_node:heritage_site': '0'
+            'group_node:infogram': '0'
+            'group_node:landing_page': '0'
+            'group_node:link': '0'
+            'group_node:news': '0'
+            'group_node:page': '0'
+            'group_node:profile': '0'
+            'group_node:project': '0'
+            'group_node:protected_area': '0'
+            'group_node:subtopic': '0'
+            'group_node:topic': '0'
+            'group_node:ual': '0'
+            'group_node:webform': '0'
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_published_date'
+        - 'config:field.storage.node.field_summary'
+  rss_publications_subtopic:
+    id: rss_publications_subtopic
+    display_title: 'Publications by subtopic'
+    display_plugin: feed
+    position: 1
+    display_options:
+      arguments:
+        field_site_subtopics_target_id:
+          id: field_site_subtopics_target_id
+          table: node__field_site_subtopics
+          field: field_site_subtopics_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: empty
+          validate_options:
+            bundles:
+              subtopic: subtopic
+            access: false
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
+      style:
+        type: rss
+        options:
+          uses_fields: false
+          description: 'RSS feed with the latest publications'
+      row:
+        type: rss_fields
+        options:
+          title_field: title
+          link_field: view_node
+          description_field: field_summary
+          creator_field: gid
+          date_field: field_published_date
+          guid_field_options:
+            guid_field: nid
+            guid_field_is_permalink: true
+      defaults:
+        arguments: false
+      display_description: ''
+      display_extenders: {  }
+      path: publications/subtopic/%/rss.xml
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_published_date'
+        - 'config:field.storage.node.field_summary'
+  rss_publications_topic:
+    id: rss_publications_topic
+    display_title: 'Publications by topics'
+    display_plugin: feed
+    position: 1
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 200
+      arguments:
+        field_site_topics_target_id:
+          id: field_site_topics_target_id
+          table: node__field_site_topics
+          field: field_site_topics_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:node'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              topic: topic
+            access: false
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
+      style:
+        type: rss
+        options:
+          uses_fields: false
+          description: 'RSS feed with the latest publications'
+      row:
+        type: rss_fields
+        options:
+          title_field: title
+          link_field: view_node
+          description_field: field_summary
+          creator_field: gid
+          date_field: field_published_date
+          guid_field_options:
+            guid_field: nid
+            guid_field_is_permalink: true
+      defaults:
+        fields: true
+        arguments: false
+      display_description: ''
+      display_extenders: {  }
+      path: publications/topic/%/rss.xml
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_published_date'
+        - 'config:field.storage.node.field_summary'

--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -6,11 +6,14 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\group\Entity\Group;
 use Drupal\node\NodeInterface;
 use Drupal\group\Entity\GroupInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_preprocess_page().
@@ -74,5 +77,18 @@ function dept_core_group_update(GroupInterface $group) {
   if ($group->bundle() === 'department_site') {
     // Invalidate the department cache when updating a group.
     Cache::invalidateTags(['department_' . $group->id()]);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function dept_core_group_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  // Redirect anon users to homepage. We allow view group entity permission
+  // to ensure the press release RSS feeds can render the parent group id
+  // value for any news nodes in the feed.
+  if (\Drupal::currentUser()->isAnonymous()) {
+    $redirect_response = new RedirectResponse('/');
+    $redirect_response->send();
   }
 }

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_application.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_application.yml
@@ -66,8 +66,20 @@ process:
       process:
         target_id: tid
   field_additional_info: field_additional_info
-  field_site_topics: field_site_topics
-  field_site_subtopics: field_site_subtopics
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_link:
     - plugin: sub_process
       source: field_link

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_article.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_article.yml
@@ -67,8 +67,20 @@ process:
       source: field_global_topics
       process:
         target_id: tid
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   moderation_state:
     plugin: static_map
     source: status

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_consultation.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_consultation.yml
@@ -81,8 +81,20 @@ process:
       source: field_global_topics
       process:
         target_id: tid
-  field_site_topics: field_site_topics
-  field_site_subtopics: field_site_subtopics
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_postal: field_postal
   field_published_date:
     - plugin: sub_process

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
@@ -61,8 +61,20 @@ process:
         paste_format: plain_text
         plain_text: plain_text
   field_map: field_map
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_original_domain: field_original_domain
 destination:
   plugin: 'entity:node'

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_gallery.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_gallery.yml
@@ -74,8 +74,20 @@ process:
       source: field_global_topics
       process:
         target_id: tid
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
 destination:
   plugin: 'entity:node'
   default_bundle: gallery

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
@@ -102,8 +102,20 @@ process:
           -
             plugin: d7_file_lookup
             source: fid
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_map: field_map
 destination:
   plugin: 'entity:node'

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
@@ -76,8 +76,20 @@ process:
   field_enable_title: field_enable_title
   field_summary: field_summary
   field_teaser: field_teaser
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_facebook_user: field_facebook_user
   field_tweet_count: field_tweet_count
   field_twitter_user: field_twitter_user

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_protected_area.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_protected_area.yml
@@ -63,8 +63,20 @@ process:
   field_council: field_council
   field_county: field_county
   field_protected_area_feature: field_protected_area_feature
-  field_site_subtopics: field_site_subtopics
-  field_site_topics: field_site_topics
+  field_site_subtopics:
+    - plugin: sub_process
+      source: field_site_subtopics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_protected_area_type: field_protected_area_type
 destination:
   plugin: 'entity:node'

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -77,11 +77,20 @@ process:
       source: field_global_topics
       process:
         target_id: tid
+  field_site_topics:
+    - plugin: sub_process
+      source: field_site_topics
+      process:
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_site_subtopics:
     - plugin: sub_process
       source: field_site_subtopics
       process:
-        target_id: tid
+        target_id:
+          - plugin: d7_node_lookup
+            source: target_id
   field_published_date:
     - plugin: sub_process
       source: field_published_date

--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -7,6 +7,7 @@
 
 use Drupal\dept_node\Entity\Node;
 use Drupal\dept_node\Form\NodeForm;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_entity_type_alter().
@@ -42,4 +43,21 @@ function dept_node_form_node_form_alter(&$form, $form_state) {
     }
   }
 
+}
+
+/**
+ * Implements hook_views_pre_render().
+ */
+function dept_node_views_pre_render(ViewExecutable $view) {
+  // Append the active site name to a few fields/titles for publications RSS.
+  if ($view->id() === 'press_releases') {
+    $site_name = \Drupal::config('system.site')->get('name');
+    $title = t('Latest press releases from ') . $site_name;
+    $view->setTitle($title);
+
+    if (\Drupal::routeMatch()->getRouteName() === 'entity.view.preview_form') {
+      \Drupal::messenger()
+        ->addWarning('NB: Title alterered in dept_node_views_pre_render()');
+    }
+  }
 }

--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -5,8 +5,10 @@
  * Departmental Node module for Departmental sites.
  */
 
+use Drupal\dept_core\Department;
 use Drupal\dept_node\Entity\Node;
 use Drupal\dept_node\Form\NodeForm;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -58,6 +60,31 @@ function dept_node_views_pre_render(ViewExecutable $view) {
     if (\Drupal::routeMatch()->getRouteName() === 'entity.view.preview_form') {
       \Drupal::messenger()
         ->addWarning('NB: Title alterered in dept_node_views_pre_render()');
+    }
+  }
+}
+
+/**
+ * Implements hook_views_query_alter().
+ *
+ * This adds the active department group id value to the WHERE clause
+ * where the group_content_field_data table has been both added as a
+ * relationship in the view config and has been added as a boilerplate
+ * filter condition to restrict o specific group.
+ */
+function dept_node_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  foreach ($query->where as $i => &$clause) {
+    foreach ($clause['conditions'] as $j => &$condition) {
+      if ($condition['field'] != 'group_content_field_data_node_field_data.gid') {
+        continue;
+      }
+
+      $dept_manager = \Drupal::service('department.manager');
+      $dept = $dept_manager->getCurrentDepartment();
+
+      if ($dept instanceof Department) {
+        $condition['value'] = $dept->groupId();
+      }
     }
   }
 }


### PR DESCRIPTION
* Migrate config change needed to ensure field_site_subtopic and field_site_topics use node lookups: they're entity reference fields looking for nodes, not taxo terms - that's the global topics field.
* Minor query adjustment needed when adding parent group relationship + filter on a view. We need to set it to the current department/group id which can't be done with the present filter options. This + distinct operator ensures that the results returned for anon + auth users are the same, subject to any node access restrictions, and the group_content_field_data records from the relationship doesn't add duplicate rows where a node sits in multiple groups.