### PR TITLE
Add .environment file to add vendor/bin to $PATH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,10 +198,10 @@ jobs:
       - run:
           name: Rebuild the Solr index
           command: |
-            platform environment:drush sapi-rt -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-            platform environment:drush sapi-c -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-            platform environment:drush sapi-r -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
-            platform environment:drush sapi-i -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH
+            platform ssh -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH /app/vendor/bin/drush sapi-rt
+            platform ssh -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH /app/vendor/bin/drush sapi-c
+            platform ssh -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH /app/vendor/bin/drush sapi-r
+            platform ssh -p $PLATFORM_PROJECT_ID -e $EDGE_BUILD_BRANCH /app/vendor/bin/drush sapi-i
           when: always
 
 # Re-usable commands.

--- a/.environment
+++ b/.environment
@@ -1,0 +1,13 @@
+# Statements in this file will be executed (sourced) by the shell in SSH
+# sessions, in deploy hooks, in cron jobs, and in the application's runtime
+# environment. This file must be placed in the root of the application, not
+# necessarily the git repository's root. In case of multiple applications,
+# each application can have its own .environment file.
+
+# .environment
+
+# Allow executable app dependencies from Composer to be run from the path.
+if [ -n "$PLATFORM_APP_DIR" -a -f "$PLATFORM_APP_DIR"/composer.json ] ; then
+  bin=$(composer config bin-dir --working-dir="$PLATFORM_APP_DIR" --no-interaction 2>/dev/null)
+  export PATH="${PLATFORM_APP_DIR}/${bin:-vendor/bin}:${PATH}"
+fi


### PR DESCRIPTION
See https://docs.platform.sh/guides/drupal9/deploy/customize.html#environment for details.

Also fixes drush commands in Circle CI for rebuilding Solr indexes overnight as prior config couldn't resolve drush as it wasn't on $PATH.