### PR TITLE
DEPT-189 Tidyup sproc and update hook to install it

### DIFF
--- a/web/modules/custom/dept_migrate/modules/dept_etgrm/dept_etgrm.install
+++ b/web/modules/custom/dept_migrate/modules/dept_etgrm/dept_etgrm.install
@@ -112,3 +112,20 @@ function dept_etgrm_update_8003() {
   $pdo->exec(file_get_contents($module_path . '/inc/sql_update_node_access.sproc'));
 }
 
+/**
+ * Introduce DELETE_STALE_IMPORTS sproc.
+ */
+function dept_etgrm_update_8004() {
+  $database = '';
+  $host = '';
+  $password = '';
+  $username = '';
+  extract(Database::getConnectionInfo('default')['default'], EXTR_OVERWRITE);
+  $module_handler = \Drupal::service('module_handler');
+  $module_path = \Drupal::service('file_system')->realpath($module_handler->getModule('dept_etgrm')->getPath());
+
+  $pdo = new PDO("mysql:host=$host;dbname=$database", $username, $password);
+
+  $pdo->exec('DROP PROCEDURE IF EXISTS DELETE_STALE_IMPORTS');
+  $pdo->exec(file_get_contents($module_path . '/inc/sql_delete_stale_imports.sproc'));
+}

--- a/web/modules/custom/dept_migrate/modules/dept_etgrm/inc/sql_delete_stale_imports.sproc
+++ b/web/modules/custom/dept_migrate/modules/dept_etgrm/inc/sql_delete_stale_imports.sproc
@@ -1,0 +1,32 @@
+CREATE PROCEDURE DELETE_STALE_IMPORTS(threshold INT)
+BEGIN
+  DECLARE completed INTEGER DEFAULT 0;
+  DECLARE iTimeStamp INTEGER DEFAULT 0;
+  DECLARE latest_ts INTEGER DEFAULT 0;
+
+  SELECT `created` INTO latest_ts FROM group_content_field_data GROUP BY `created` HAVING COUNT(`id`) >= threshold ORDER BY `created` DESC LIMIT 1;
+
+  BEGIN
+    # Cursor handling
+    DECLARE ts_cursor CURSOR FOR
+      SELECT `created` FROM group_content_field_data WHERE `created` != latest_ts GROUP BY `created` HAVING COUNT(`id`) >= threshold ORDER BY `created` ASC;
+    DECLARE CONTINUE HANDLER
+      FOR NOT FOUND SET completed = 1;
+
+    OPEN ts_cursor;
+    tidyDataLoop: LOOP
+      FETCH ts_cursor INTO iTimeStamp;
+
+      IF completed = 1 THEN
+        LEAVE tidyDataLoop;
+      END IF;
+
+      DELETE group_content, group_content_field_data
+      FROM group_content
+      INNER JOIN group_content_field_data ON group_content.id = group_content_field_data.id
+      WHERE group_content_field_data.created = iTimeStamp;
+
+    END LOOP tidyDataLoop;
+    CLOSE ts_cursor;
+  END;
+END

--- a/web/modules/custom/dept_migrate/modules/dept_etgrm/src/Commands/EtgrmCommands.php
+++ b/web/modules/custom/dept_migrate/modules/dept_etgrm/src/Commands/EtgrmCommands.php
@@ -121,6 +121,10 @@ class EtgrmCommands extends DrushCommands {
     $query = $pdo->query('call UPDATE_NODE_ACCESS()');
     $this->io()->writeln(" ✅");
 
+    $this->io()->write("Tidying up any stale previous timestamped imports");
+    $query = $pdo->query('call DELETE_STALE_IMPORTS(1000)');
+    $this->io()->writeln(" ✅");
+
     $conf->set('processed_ts', $ts);
     $conf->save();
 


### PR DESCRIPTION
A pragmatic approach to drop any rows associated with older bulk update timestamps - we used the `created` timestamp as a kind of batch id; the last one is always stored in the dept_etgrm.data config value.

Occasionally, something doesn't go quite right and it doesn't tidy up the previous bulk update's data before rebuilding resulting in duplicate sets in the group_content tables meaning you get duplicates coming out on the front-end when the underlying queries return multiple values per content item.

So essentially this sproc looks for the most recent timestamp with lots of rows associated with it (over 1k as a baseline), then loops through any others that are older, and removes the rows associated with that timestamp.

We do this at the end of the process of rebuilding the group relationships and it should keep things ship-shape and cover over any oddities with future migrate process interruptions and fits in with any ad hoc drush command usage too. Once all sites are migrated, it all gets switched off anyhow.