### PR TITLE
DEPT-194 Add extra config from NIDirect, default to disabled logging for now

### DIFF
--- a/config/sync/csp.settings.yml
+++ b/config/sync/csp.settings.yml
@@ -9,6 +9,8 @@ report-only:
       base: self
       sources:
         - 'https://www.google-analytics.com'
+        - 'https://*.newrelic.com'
+        - 'https://*.nr-data.net'
     font-src:
       base: self
       sources:
@@ -20,6 +22,7 @@ report-only:
       base: self
       sources:
         - 'https://www.youtube.com'
+        - 'https://www.vimeo.com'
     img-src:
       base: self
       sources:
@@ -39,6 +42,8 @@ report-only:
       sources:
         - 'https://www.googletagmanager.com'
         - 'https://www.google-analytics.com'
+        - 'https://*.newrelic.com'
+        - 'https://*.nr-data.net'
     script-src-attr:
       base: self
     script-src-elem:
@@ -46,6 +51,8 @@ report-only:
       sources:
         - 'https://www.googletagmanager.com'
         - 'https://www.google-analytics.com'
+        - 'https://*.newrelic.com'
+        - 'https://*.nr-data.net'
     style-src:
       base: self
     style-src-attr:
@@ -56,7 +63,7 @@ report-only:
       base: self
     block-all-mixed-content: true
   reporting:
-    plugin: sitelog
+    plugin: none
 enforce:
   enable: false
   directives:
@@ -73,6 +80,7 @@ enforce:
       base: self
       sources:
         - 'https://www.youtube.com'
+        - 'https://www.vimeo.com'
     img-src:
       base: self
       sources:
@@ -104,4 +112,4 @@ enforce:
         - 'https://www.google-analytics.com'
     block-all-mixed-content: true
   reporting:
-    plugin: sitelog
+    plugin: none


### PR DESCRIPTION
Can enable remote logging once a service is selected and activated. Otherwise, dblog is likely to flood with notices once in production.