### PR TITLE
Double the Solr service disk allowance

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -32,7 +32,7 @@ relationships:
   drupal7db: 'drupal7db:admin'
 
 # The size of the persistent disk of the application (in MB).
-disk: 99500
+disk: 99000
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -32,7 +32,7 @@ drupal7db:
 # Fudging the service name forces a full rebuild with any new config.
 solr:
   type: solr:7.7
-  disk: 512
+  disk: 1024
   configuration:
     cores:
       default:


### PR DESCRIPTION
Current dev plan states 120GB of free space. We have 99 allocated to the app server, then 10 for D9 db and 10 for D7 db, and now 1 for Solr.