### PR TITLE
DEPT-255 turn off content moderation for importing nodes + updates to them

### DIFF
--- a/config/sync/migrate_plus.migration.node_actions.yml
+++ b/config/sync/migrate_plus.migration.node_actions.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_application.yml
+++ b/config/sync/migrate_plus.migration.node_application.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_article.yml
+++ b/config/sync/migrate_plus.migration.node_article.yml
@@ -99,12 +99,7 @@ process:
           -
             plugin: d7_node_lookup
             source: target_id
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_collection.yml
+++ b/config/sync/migrate_plus.migration.node_collection.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_consultation.yml
+++ b/config/sync/migrate_plus.migration.node_consultation.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_contact.yml
+++ b/config/sync/migrate_plus.migration.node_contact.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: timestamp
   promote: promote

--- a/config/sync/migrate_plus.migration.node_easychart.yml
+++ b/config/sync/migrate_plus.migration.node_easychart.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_gallery.yml
+++ b/config/sync/migrate_plus.migration.node_gallery.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_heritage_site.yml
+++ b/config/sync/migrate_plus.migration.node_heritage_site.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_infogram.yml
+++ b/config/sync/migrate_plus.migration.node_infogram.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_landing_page.yml
+++ b/config/sync/migrate_plus.migration.node_landing_page.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_link.yml
+++ b/config/sync/migrate_plus.migration.node_link.yml
@@ -38,12 +38,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_news.yml
+++ b/config/sync/migrate_plus.migration.node_news.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_page.yml
+++ b/config/sync/migrate_plus.migration.node_page.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_profile.yml
+++ b/config/sync/migrate_plus.migration.node_profile.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_protected_area.yml
+++ b/config/sync/migrate_plus.migration.node_protected_area.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -33,12 +33,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_subtopic.yml
+++ b/config/sync/migrate_plus.migration.node_subtopic.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_topic.yml
+++ b/config/sync/migrate_plus.migration.node_topic.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/config/sync/migrate_plus.migration.node_ual.yml
+++ b/config/sync/migrate_plus.migration.node_ual.yml
@@ -31,12 +31,7 @@ process:
     -
       plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      - draft
-      - published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -34,6 +34,7 @@ then
   do
     $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_group_$type/config/install -y
   done
+  echo "NB: Content moderation config is temporarily turned off as it interferes with importing changes from D7..."
 
 #  echo "Migrating D7 taxonomy data"
 #  $DRUSH migrate:import --group=migrate_drupal_7_taxo --force
@@ -89,6 +90,9 @@ then
 
   echo "Updating content links"
   $DRUSH dept:updatelinks
+
+  echo "Restoring config from config/sync"
+  $DRUSH cim -y
 
   echo ".... DONE"
 fi

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_actions.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_actions.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_application.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_application.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_article.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_article.yml
@@ -81,12 +81,7 @@ process:
         target_id:
           - plugin: d7_node_lookup
             source: target_id
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_collection.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_collection.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_consultation.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_consultation.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: timestamp
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_easychart.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_easychart.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_gallery.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_gallery.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_infogram.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_infogram.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_link.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_link.yml
@@ -30,12 +30,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_news.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_news.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_page.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_profile.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_profile.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_protected_area.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_protected_area.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -26,12 +26,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_subtopic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_subtopic.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_topic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_topic.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_ual.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_ual.yml
@@ -24,12 +24,7 @@ process:
   uid:
     - plugin: d7_user_lookup
       source: node_uid
-  moderation_state:
-    plugin: static_map
-    source: status
-    map:
-      0: draft
-      1: published
+  status: status
   created: created
   changed: changed
   promote: promote

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/workflows.workflow.nics_editorial_workflow.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/workflows.workflow.nics_editorial_workflow.yml
@@ -1,0 +1,92 @@
+uuid: d9278ee1-160d-42a3-b4f4-31ea527d58d4
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+_core:
+  default_config_hash: Tk4jVzihIcXtxZREjwCMLydvSVPKzgW1Lph-NY45Ay8
+id: nics_editorial_workflow
+label: 'NICS Editorial Workflow'
+type: content_moderation
+type_settings:
+  states:
+    archived:
+      label: Archived
+      weight: 3
+      published: false
+      default_revision: true
+    draft:
+      label: Draft
+      weight: 0
+      published: false
+      default_revision: false
+    needs_review:
+      label: 'Needs Review'
+      weight: 2
+      published: false
+      default_revision: false
+    published:
+      label: Published
+      weight: 1
+      published: true
+      default_revision: true
+  transitions:
+    archive:
+      label: Archive
+      from:
+        - draft
+        - needs_review
+        - published
+      to: archived
+      weight: 3
+    create_new_draft:
+      label: 'Create New Draft'
+      from:
+        - draft
+      to: draft
+      weight: -3
+    draft_of_published:
+      label: 'Draft of Published'
+      from:
+        - published
+      to: draft
+      weight: 6
+    publish:
+      label: Publish
+      from:
+        - needs_review
+      to: published
+      weight: 1
+    quick_publish:
+      label: 'Quick Publish'
+      from:
+        - draft
+        - published
+      to: published
+      weight: -1
+    reject:
+      label: Reject
+      from:
+        - needs_review
+      to: draft
+      weight: 0
+    restore:
+      label: Restore
+      from:
+        - archived
+      to: published
+      weight: 5
+    restore_to_draft:
+      label: 'Restore to Draft'
+      from:
+        - archived
+      to: draft
+      weight: 4
+    submit_for_review:
+      label: 'Submit for Review'
+      from:
+        - draft
+      to: needs_review
+      weight: -2
+  default_moderation_state: draft

--- a/web/modules/custom/dept_migrate/src/MigrateUuidLookupManager.php
+++ b/web/modules/custom/dept_migrate/src/MigrateUuidLookupManager.php
@@ -98,6 +98,11 @@ class MigrateUuidLookupManager {
       $migrate_map = $this->dbconn->query("SELECT * from ${table} WHERE sourceid1 = :uuid", [':uuid' => $d7uuid]);
 
       foreach ($migrate_map as $row) {
+        if (empty($row->destid1)) {
+          $this->logger->error('No D9 node found for D7 node id ' . $row->sourceid2);
+          continue;
+        }
+
         $node = $this->entityTypeManager->getStorage('node')->load($row->destid1);
 
         if (empty($node)) {

--- a/web/modules/custom/dept_migrate/src/Plugin/migrate/process/D7FileLookup.php
+++ b/web/modules/custom/dept_migrate/src/Plugin/migrate/process/D7FileLookup.php
@@ -86,7 +86,8 @@ class D7FileLookup extends ProcessPluginBase implements ContainerFactoryPluginIn
     }
 
     if (!empty($entity_metadata)) {
-      $value = reset($entity_metadata)['id'];
+      $entity_metadata = reset($entity_metadata);
+      $value = $entity_metadata['id'] ?? [];
     }
 
     return $value ?? [];

--- a/web/modules/custom/dept_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
+++ b/web/modules/custom/dept_migrate/src/Plugin/migrate/process/MediaWysiwygFilter.php
@@ -115,7 +115,7 @@ class MediaWysiwygFilter extends ProcessPluginBase implements ContainerFactoryPl
     // Convert from D7 to D9 node id.
     $lookup = $this->lookupManager->lookupBySourceNodeId([$nid]);
     $lookup = reset($lookup);
-    $nid = $lookup['nid'];
+    $nid = $lookup['nid'] ?? 0;
 
     $value['value'] = preg_replace_callback($pattern, function ($matches) use ($messenger, $nid) {
       $decoder = new JsonDecode(TRUE);


### PR DESCRIPTION
Content moderation (CM) doesn't seem to get on with migrations that track and import changes over time. You either end up with a busy and unnecessary revisions list (fixed with patch to provide suitable use of sync attribute in migrate module) or creating new drafts on migrated content creates a jumble of content moderation entity revisions which look very complex to detangle.

Removing any moderation YML, turning off CM and then importing changes (new and updated) works well. You can then turn on CM again and continue to make drafts which then show the correct changes.