### PR TITLE
DEPT-232: fix WSOD when selecting facets

### DIFF
--- a/config/sync/facets.facet_source.search_api__views_page__consultations_search__consultations_search.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__consultations_search__consultations_search.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 id: search_api__views_page__consultations_search__consultations_search
 name: 'search_api:views_page__consultations_search__consultations_search'
 filter_key: ''
-url_processor: facets_pretty_paths
+url_processor: query_string
 breadcrumb:
   active: false
   before: true

--- a/config/sync/facets.facet_source.search_api__views_page__news_search__news_search.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__news_search__news_search.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 id: search_api__views_page__news_search__news_search
 name: 'search_api:views_page__news_search__news_search'
 filter_key: ''
-url_processor: facets_pretty_paths
+url_processor: query_string
 breadcrumb:
   active: false
   before: true

--- a/config/sync/facets.facet_source.search_api__views_page__press_release_search__pr_search_page.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__press_release_search__pr_search_page.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 id: search_api__views_page__press_release_search__pr_search_page
 name: 'search_api:views_page__press_release_search__pr_search_page'
 filter_key: ''
-url_processor: facets_pretty_paths
+url_processor: query_string
 breadcrumb:
   active: false
   before: true

--- a/config/sync/facets.facet_source.search_api__views_page__publications_search__publications_search.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__publications_search__publications_search.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 id: search_api__views_page__publications_search__publications_search
 name: 'search_api:views_page__publications_search__publications_search'
 filter_key: ''
-url_processor: facets_pretty_paths
+url_processor: query_string
 breadcrumb:
   active: false
   before: true


### PR DESCRIPTION
Also fixes https://digitaldevelopment.atlassian.net/browse/DEPT-233

The facets_pretty_paths module is breaking facets. Tried updating to the latest patch on https://www.drupal.org/project/facets_pretty_paths/issues/3254600 - but no joy.

Disabling facets pretty paths url processor and using the query string processor instead resolves the problem.  The facets pretty paths url processor can be re-enabled when https://www.drupal.org/project/facets_pretty_paths/issues/3254600 is resolved.