### PR TITLE
Reconcile two clashing d.o. patches into single patch file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -272,7 +272,7 @@
                 "Incompatibilities between facets_pretty_paths and facets 2.0": "https://www.drupal.org/files/issues/2022-03-09/facet_summary_reset-3268360-3.patch"
             },
             "drupal/facets_pretty_paths": {
-                "Cannot filter properly when using facet pretty paths": "https://www.drupal.org/files/issues/2022-01-11/url-duplication.patch"
+                "Composite patch for issues 2952005 and 3254600": "https://gist.githubusercontent.com/johangant/00ba5b48ea73dc23c68fa31389e59b31/raw/867a56ab06bce67f9cbfae65d3dd3b974e09b92a/fpp-result-count-query-handler.patch"
             },
             "drupal/date_facet_drilldown": {
                 "Enable support for facet query string": "https://www.drupal.org/files/issues/2022-11-09/date_facet_drilldown-3320111-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e3e994b8a6842e6f1fd1a8e40a2fefb",
+    "content-hash": "d0e93e9f7f2f494417a800dcaec9892c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -17587,5 +17587,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/config/sync/facets.facet_source.search_api__views_page__news_search__news_search.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__news_search__news_search.yml
@@ -5,7 +5,7 @@ dependencies: {  }
 id: search_api__views_page__news_search__news_search
 name: 'search_api:views_page__news_search__news_search'
 filter_key: ''
-url_processor: query_string
+url_processor: facets_pretty_paths
 breadcrumb:
   active: false
   before: true


### PR DESCRIPTION
Drupal.org issues that are related, but clash a little:

* https://www.drupal.org/node/2952005
* https://www.drupal.org/node/3254600

Fixes facet results count, reset/remove link and compatibility with contextual args on views.