### PR TITLE
Move solr reindex to psh cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,21 +189,6 @@ jobs:
           name: Trigger a data sync from production environment to an edge build.
           command: |
             platform sync data -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH -y
-      - run:
-          name: Force purge of Solr index
-          command: |
-            platform ssh -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH \
-              "curl http://${PLATFORM_SOLR_HOST}/solr/default/update --data '<delete><query>*:*</query></delete>' -H 'Content-type:text/xml; charset=utf-8' && curl http://${PLATFORM_SOLR_HOST}/solr/default/update --data '<commit/>' -H 'Content-type:text/xml; charset=utf-8'"
-          when: always
-      - run:
-          name: Rebuild the Solr index
-          command: |
-            platform ssh -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH "drush sapi-rt"
-            platform ssh -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH "drush sapi-c"
-            platform ssh -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH "drush sapi-r"
-            platform ssh -p $PLATFORM_PROJECT -e $EDGE_BUILD_BRANCH "drush sapi-i --batch-size=250"
-          when: always
-          no_output_timeout: 20m
 
 # Re-usable commands.
 commands:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -165,15 +165,18 @@ web:
 
 # Set up migration content refresh every night.
 crons:
+  daily_edge_solr_reindex:
+    spec: '0 6 * * 0-5'
+    cmd: './reindex-edge-solr.sh'
   d7db:
     spec: '0 1 * * *'
     cmd: 'migrate-scripts/sync-db.sh $D7_PROJECT_ID $D7_PROJECT_ENV'
-  sync_files:
-    spec: '30 0 * * *'
-    cmd: 'migrate-scripts/sync-private-files.sh $D7_PROJECT_ID $D7_PROJECT_ENV'
-  migrate:
-    spec: '30 2 * * *'
-    cmd: 'migrate-scripts/migrate.sh 2>&1 | tee /app/imports/last-migrate-output.txt'
   drupal:
     spec: '*/15 * * * *'
     cmd: 'vendor/bin/drush cron'
+  migrate:
+    spec: '30 2 * * *'
+    cmd: 'migrate-scripts/migrate.sh 2>&1 | tee /app/imports/last-migrate-output.txt'
+  sync_files:
+    spec: '30 0 * * *'
+    cmd: 'migrate-scripts/sync-private-files.sh $D7_PROJECT_ID $D7_PROJECT_ENV'

--- a/reindex-edge-solr.sh
+++ b/reindex-edge-solr.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+PLATFORM_SOLR_HOST=solr.internal:8080
+
+echo "Force purge of Solr service contents..."
+curl http://${PLATFORM_SOLR_HOST}/solr/default/update --data '<delete><query>*:*</query></delete>' -H 'Content-type:text/xml; charset=utf-8'
+curl http://${PLATFORM_SOLR_HOST}/solr/default/update --data '<commit/>' -H 'Content-type:text/xml; charset=utf-8'
+
+echo "Reset Solr tracker index"
+drush sapi-rt
+echo "Clear Solr indexes"
+drush sapi-c
+echo "Mark all content for re-indexing"
+drush sapi-r
+echo "Reindex all active indices"
+drush sapi-i --batch-size=250
+
+echo "DONE"

--- a/reindex-edge-solr.sh
+++ b/reindex-edge-solr.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 PLATFORM_SOLR_HOST=solr.internal:8080
 
+if [ ${PLATFORM_BRANCH} != "DEPT-edge" ];
+then
+  # Not running on the edge environment, exit.
+  exit 0
+fi
+
 echo "Force purge of Solr service contents..."
 curl http://${PLATFORM_SOLR_HOST}/solr/default/update --data '<delete><query>*:*</query></delete>' -H 'Content-type:text/xml; charset=utf-8'
 curl http://${PLATFORM_SOLR_HOST}/solr/default/update --data '<commit/>' -H 'Content-type:text/xml; charset=utf-8'


### PR DESCRIPTION
Takes 50 minutes of CI compute time, Mon-Fri, and runs it on platform.sh's own cron handler to save :moneybag: :moneybag: :moneybag: 