### PR TITLE
Fix paths and inclusions for Twig debugging etc when installing project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@
 /web/libraries/
 console/
 
-# Ignore sensitive information
+# Ignore sensitive information or local config.
 /web/sites/*/settings.local.php
+/web/sites/local.development.services.yml
 
 # Ignore Drupal's files directory
 /web/sites/*/files/

--- a/.lando/config/drupal.services.yml
+++ b/.lando/config/drupal.services.yml
@@ -3,47 +3,10 @@
 # To activate this feature, follow the instructions at the top of the
 # 'example.settings.local.php' file, which sits next to this file.
 parameters:
-  twig.config:
-    # Twig debugging:
-    #
-    # When debugging is enabled:
-    # - The markup of each Twig template is surrounded by HTML comments that
-    #   contain theming information, such as template file name suggestions.
-    # - Note that this debugging markup will cause automated tests that directly
-    #   check rendered HTML to fail. When running automated tests, 'debug'
-    #   should be set to FALSE.
-    # - The dump() function can be used in Twig templates to output information
-    #   about template variables.
-    # - Twig templates are automatically recompiled whenever the source code
-    #   changes (see auto_reload below).
-    #
-    # For more information about debugging Twig templates, see
-    # https://www.drupal.org/node/1906392.
-    #
-    # Not recommended in production environments
-    # @default false
-    debug: true
-    # Twig auto-reload:
-    #
-    # Automatically recompile Twig templates whenever the source code changes.
-    # If you don't provide a value for auto_reload, it will be determined
-    # based on the value of debug.
-    #
-    # Not recommended in production environments
-    # @default null
-    auto_reload: null
-    # Twig cache:
-    #
-    # By default, Twig templates will be compiled and stored in the filesystem
-    # to increase performance. Disabling the Twig cache will recompile the
-    # templates from source each time they are used. In most cases the
-    # auto_reload setting above should be enabled rather than disabling the
-    # Twig cache.
-    #
-    # Not recommended in production environments
-    # @default true
-    cache: false
   http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    cache: false
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory

--- a/.lando/config/drupal.settings.php
+++ b/.lando/config/drupal.settings.php
@@ -1,7 +1,11 @@
 <?php
 
 // @codingStandardsIgnoreFile
-$settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.development.yml';
+$local_services_config = $app_root . '/sites/local.development.services.yml';
+if (file_exists($local_services_config)) {
+  $settings['container_yamls'][] = $local_services_config;
+}
+
 $settings['file_private_path'] = getenv('FILE_PRIVATE_PATH');
 
 $databases['default']['default'] = [

--- a/.lando/scripts/appserver_build.sh
+++ b/.lando/scripts/appserver_build.sh
@@ -37,8 +37,9 @@ if [ ! -d "/app/.lando/private" ]; then
 fi
 
 if [ ! -d $DRUPAL_ROOT/sites/default/settings.local.php ]; then
-  echo "Creating local Drupal settings file"
+  echo "Creating local Drupal settings and developent services files"
   cp -v /app/.lando/config/drupal.settings.php $DRUPAL_ROOT/sites/default/settings.local.php
+  cp -v /app/.lando/config/drupal.services.yml $DRUPAL_ROOT/sites/local.development.services.yml
 fi
 
 #echo "Copying Redis service overrides"


### PR DESCRIPTION
When the project installs, it'll move two template files into place - one for local settings and one for local services config. To date they've not quite been joined up, but now they should be and it'll make http header + twig template suggestions appear by default for local development + make it easier to adjust.