### PR TITLE
Make latest news use distinct query operator

### DIFF
--- a/config/sync/views.view.news.yml
+++ b/config/sync/views.view.news.yml
@@ -486,8 +486,18 @@ display:
         options:
           relationship: none
           view_mode: list_with_publish_date
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+          contextual_filters_or: false
       defaults:
         empty: false
+        query: false
         title: false
         pager: false
         use_more: false


### PR DESCRIPTION
Possible side effect of dept_node's hook_grant alterations mixing with other things. I know that's being reviewed a little now so opting for a distinct query operator to patch this over right now and avoid any duplicate rows