### PR TITLE
Update migration mapping for contacts using new map location field

### DIFF
--- a/config/sync/core.entity_form_display.node.contact.default.yml
+++ b/config/sync/core.entity_form_display.node.contact.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.node.contact.body
-    - field.field.node.contact.field_map
     - field.field.node.contact.field_map_location
     - field.field.node.contact.field_metatags
     - field.field.node.contact.field_next_audit_due
@@ -17,7 +16,6 @@ dependencies:
     - content_moderation
     - datetime
     - geolocation_google_maps
-    - google_map_field
     - metatag
     - path
     - scheduler
@@ -40,12 +38,6 @@ content:
   created:
     type: datetime_timestamp
     weight: 6
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_map:
-    type: google_map_field_default
-    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.contact.default.yml
+++ b/config/sync/core.entity_view_display.node.contact.default.yml
@@ -4,12 +4,12 @@ status: true
 dependencies:
   config:
     - field.field.node.contact.body
-    - field.field.node.contact.field_map
     - field.field.node.contact.field_map_location
     - field.field.node.contact.field_metatags
     - field.field.node.contact.field_next_audit_due
     - field.field.node.contact.field_site_subtopics
     - field.field.node.contact.field_site_topics
+    - filter.format.plain_text
     - node.type.contact
   module:
     - geolocation
@@ -21,24 +21,97 @@ bundle: contact
 mode: default
 content:
   field_map_location:
-    type: geolocation_latlng
+    type: geolocation_map
     label: above
-    settings: {  }
+    settings:
+      set_marker: true
+      show_label: false
+      common_map: true
+      show_delta_label: false
+      use_overridden_map_settings: false
+      title: ''
+      info_text:
+        value: ''
+        format: plain_text
+      centre:
+        fit_bounds:
+          enable: true
+          weight: -101
+          settings:
+            reset_zoom: true
+            min_zoom: null
+          map_center_id: fit_bounds
+        fixed_boundaries:
+          enable: false
+          weight: 0
+          settings:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          map_center_id: fixed_boundaries
+        client_location:
+          enable: false
+          weight: 0
+          map_center_id: client_location
+        fixed_value:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: fixed_value
+            latitude: null
+            longitude: null
+          map_center_id: location_plugins
+        ipstack:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: ipstack
+            access_key: ''
+          map_center_id: location_plugins
+      map_provider_id: google_static_maps
+      map_provider_settings:
+        map_features:
+          geolocation_shapes:
+            weight: 0
+            settings:
+              remove_markers: false
+              polyline: true
+              polyline_title: ''
+              strokeColor: '#FF0000'
+              strokeOpacity: 0.8
+              strokeWidth: '2'
+              polygon: false
+              polygon_title: ''
+              fillColor: '#FF0000'
+              fillOpacity: 0.35
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+        type: ROADMAP
+        zoom: 10
+        height: null
+        width: null
+        format: png
+        scale: 1
+      data_provider_settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   field_metatags:
     type: metatag_empty_formatter
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
 hidden:
   body: true
   content_moderation_control: true
   entitygroupfield: true
-  field_map: true
   field_next_audit_due: true
   field_site_subtopics: true
   field_site_topics: true

--- a/config/sync/core.entity_view_display.node.contact.diff.yml
+++ b/config/sync/core.entity_view_display.node.contact.diff.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.diff
     - field.field.node.contact.body
-    - field.field.node.contact.field_map
     - field.field.node.contact.field_map_location
     - field.field.node.contact.field_metatags
     - field.field.node.contact.field_next_audit_due
@@ -387,7 +386,6 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
-  field_map: true
   field_metatags: true
   field_next_audit_due: true
   groups: true

--- a/config/sync/core.entity_view_display.node.contact.full.yml
+++ b/config/sync/core.entity_view_display.node.contact.full.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.contact.body
-    - field.field.node.contact.field_map
     - field.field.node.contact.field_map_location
     - field.field.node.contact.field_metatags
     - field.field.node.contact.field_next_audit_due
@@ -349,7 +348,6 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
-  field_map: true
   field_metatags: true
   field_next_audit_due: true
   field_site_subtopics: true

--- a/config/sync/core.entity_view_display.node.contact.search_result.yml
+++ b/config/sync/core.entity_view_display.node.contact.search_result.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.contact.body
-    - field.field.node.contact.field_map
     - field.field.node.contact.field_map_location
     - field.field.node.contact.field_metatags
     - field.field.node.contact.field_next_audit_due
@@ -49,7 +48,6 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
-  field_map: true
   field_map_location: true
   field_metatags: true
   field_next_audit_due: true

--- a/config/sync/core.entity_view_display.node.contact.teaser.yml
+++ b/config/sync/core.entity_view_display.node.contact.teaser.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.contact.body
-    - field.field.node.contact.field_map
     - field.field.node.contact.field_map_location
     - field.field.node.contact.field_metatags
     - field.field.node.contact.field_next_audit_due
@@ -36,7 +35,6 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
-  field_map: true
   field_map_location: true
   field_metatags: true
   field_next_audit_due: true

--- a/config/sync/migrate_plus.migration.node_contact.yml
+++ b/config/sync/migrate_plus.migration.node_contact.yml
@@ -75,7 +75,8 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  field_map: field_map
+  field_map_location/lng: field_map/0/lon
+  field_map_location/lat: field_map/0/lat
   field_site_subtopics:
     -
       plugin: sub_process

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_contact.yml
@@ -62,7 +62,8 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
-  field_map: field_map
+  field_map_location/lng: field_map/0/lon
+  field_map_location/lat: field_map/0/lat
   field_site_subtopics:
     - plugin: sub_process
       source: field_site_subtopics


### PR DESCRIPTION
Map field config for display can be adjusted as required - currently set to use Google static map with out of the box defaults.

Heritage site also uses the same maps so probably needs updating, separately.