### PR TITLE
Dept 256  subtopics with articles and other subtopics

### DIFF
--- a/web/modules/custom/dept_node/src/ContentTopics.php
+++ b/web/modules/custom/dept_node/src/ContentTopics.php
@@ -166,4 +166,53 @@ class ContentTopics {
     return $render;
   }
 
+  /**
+   * @param int|\Drupal\node\NodeInterface $node
+   *   The subtopic node (nid or full object)
+   *
+   * @return array
+   *   A render array of links elements.
+   */
+  public function getSubtopicContent(int|NodeInterface $node): array {
+    $content = [];
+
+    if (empty($node)) {
+      return $content;
+    }
+
+    if (is_int($node)) {
+      $node = $this->entityTypeManager->getStorage('node')->load($node);
+    }
+
+    if ($node instanceof NodeInterface && $node->bundle() === 'subtopic') {
+      // Fetch articles tagged with this subtopic, as well as subtopics
+      // referencing it from the parent subtopic field.
+      $subtopic_content_sql = "SELECT
+        st_nfd.nid,
+        st_nfd.type,
+        st_nfd.title
+        FROM {node_field_data} st_nfd
+        JOIN {node__field_parent_subtopic} nfps ON st_nfd.nid = nfps.entity_id
+        WHERE st_nfd.type = 'subtopic' AND nfps.field_parent_subtopic_target_id = :subtopic_id
+      UNION
+        SELECT
+        ar_nfd.nid,
+        ar_nfd.type,
+        ar_nfd.title
+        FROM {node_field_data} ar_nfd
+        JOIN {node__field_site_subtopics} nfss ON ar_nfd.nid = nfss.entity_id
+        WHERE ar_nfd.type = 'article' AND nfss.field_site_subtopics_target_id = :subtopic_id";
+
+      $subtopic_content = \Drupal::database()
+        ->query($subtopic_content_sql, [':subtopic_id' => $node->id()])
+        ->fetchAll();
+
+      foreach ($subtopic_content as $row) {
+        $content[] = Link::createFromRoute($row->title, 'entity.node.canonical', ['node' => $row->nid])->toString();
+      }
+    }
+
+    return $content;
+  }
+
 }

--- a/web/modules/custom/dept_node/src/ContentTopics.php
+++ b/web/modules/custom/dept_node/src/ContentTopics.php
@@ -194,6 +194,7 @@ class ContentTopics {
         FROM {node_field_data} st_nfd
         JOIN {node__field_parent_subtopic} nfps ON st_nfd.nid = nfps.entity_id
         WHERE st_nfd.type = 'subtopic' AND nfps.field_parent_subtopic_target_id = :subtopic_id
+        AND st_nfd.status = 1
       UNION
         SELECT
         ar_nfd.nid,
@@ -201,7 +202,8 @@ class ContentTopics {
         ar_nfd.title
         FROM {node_field_data} ar_nfd
         JOIN {node__field_site_subtopics} nfss ON ar_nfd.nid = nfss.entity_id
-        WHERE ar_nfd.type = 'article' AND nfss.field_site_subtopics_target_id = :subtopic_id";
+        WHERE ar_nfd.type = 'article' AND nfss.field_site_subtopics_target_id = :subtopic_id
+        AND ar_nfd.status = 1";
 
       $subtopic_content = \Drupal::database()
         ->query($subtopic_content_sql, [':subtopic_id' => $node->id()])

--- a/web/modules/custom/dept_node/src/ContentTopics.php
+++ b/web/modules/custom/dept_node/src/ContentTopics.php
@@ -203,7 +203,8 @@ class ContentTopics {
         FROM {node_field_data} ar_nfd
         JOIN {node__field_site_subtopics} nfss ON ar_nfd.nid = nfss.entity_id
         WHERE ar_nfd.type = 'article' AND nfss.field_site_subtopics_target_id = :subtopic_id
-        AND ar_nfd.status = 1";
+        AND ar_nfd.status = 1
+      ORDER BY title ASC";
 
       $subtopic_content = \Drupal::database()
         ->query($subtopic_content_sql, [':subtopic_id' => $node->id()])

--- a/web/modules/custom/dept_topics/dept_topics.module
+++ b/web/modules/custom/dept_topics/dept_topics.module
@@ -95,6 +95,17 @@ function dept_topics_preprocess_node(array &$variables) {
       }
     }
   }
+
+  if ($node->bundle() === 'subtopic' && $view_mode === 'full') {
+    $subtopics_content = \Drupal::service('dept_node.topics')
+      ->getSubtopicContent($node->id());
+
+    $variables['content'][] = [
+      '#theme' => 'item_list',
+      '#list_type' => 'ul',
+      '#items' => $subtopics_content,
+    ];
+  }
 }
 
 /**

--- a/web/modules/custom/dept_topics/dept_topics.module
+++ b/web/modules/custom/dept_topics/dept_topics.module
@@ -8,7 +8,6 @@
 
 use Drupal\Core\Link;
 use Drupal\dept_core\Department;
-use Drupal\entityqueue\EntityQueueInterface;
 use Drupal\node\NodeInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
@@ -50,11 +49,26 @@ function dept_topics_preprocess_node(array &$variables) {
           $ids = $query->execute();
         }
 
-        $article_nodes = \Drupal::entityTypeManager()
-          ->getStorage('node')->loadMultiple(array_keys($ids));
+        // We need to merge in any other subtopic nodes referencing this
+        // subtopic.
+        $subtopic_ref_ids = \Drupal::entityQuery('node')
+          ->condition('type', 'subtopic')
+          ->condition('status', 1)
+          ->condition('field_parent_subtopic', $subtopic_id)
+          ->sort('changed', 'DESC')->execute();
+
+        if (!empty($subtopic_ref_ids)) {
+          $ids_to_load = array_merge(array_keys($subtopic_ref_ids), array_keys($ids));
+        }
+        else {
+          $ids_to_load = array_keys($ids);
+        }
+
+        $subtopic_ref_nodes = \Drupal::entityTypeManager()
+          ->getStorage('node')->loadMultiple($ids_to_load);
 
         $content_links = [];
-        foreach ($article_nodes as $content_node) {
+        foreach ($subtopic_ref_nodes as $content_node) {
           /** @var \Drupal\node\NodeInterface $content_node */
           $content_links[] = $content_node->toLink()->toRenderable();
         }

--- a/web/modules/custom/dept_topics/dept_topics.module
+++ b/web/modules/custom/dept_topics/dept_topics.module
@@ -39,38 +39,21 @@ function dept_topics_preprocess_node(array &$variables) {
           ->orderBy('weight', 'ASC');
 
         $ids = $query->execute()->fetchAllAssoc('entity_id');
+
         if (empty($ids)) {
-          // Replace with naturally sorted list.
-          $query = \Drupal::entityQuery('node')
-            ->condition('type', 'article')
-            ->condition('status', 1)
-            ->condition('field_site_subtopics', $subtopic_id)
-            ->sort('changed', 'DESC');
-          $ids = $query->execute();
-        }
-
-        // We need to merge in any other subtopic nodes referencing this
-        // subtopic.
-        $subtopic_ref_ids = \Drupal::entityQuery('node')
-          ->condition('type', 'subtopic')
-          ->condition('status', 1)
-          ->condition('field_parent_subtopic', $subtopic_id)
-          ->sort('changed', 'DESC')->execute();
-
-        if (!empty($subtopic_ref_ids)) {
-          $ids_to_load = array_merge(array_keys($subtopic_ref_ids), array_keys($ids));
+          // If not sorted by draggableviews, then fall back to using the
+          // service to fetch content for a subtopic.
+          $content_links = \Drupal::service('dept_node.topics')->getSubtopicContent($subtopic_id);
         }
         else {
-          $ids_to_load = array_keys($ids);
-        }
+          $subtopic_ref_nodes = \Drupal::entityTypeManager()
+            ->getStorage('node')->loadMultiple(array_keys($ids));
 
-        $subtopic_ref_nodes = \Drupal::entityTypeManager()
-          ->getStorage('node')->loadMultiple($ids_to_load);
-
-        $content_links = [];
-        foreach ($subtopic_ref_nodes as $content_node) {
-          /** @var \Drupal\node\NodeInterface $content_node */
-          $content_links[] = $content_node->toLink()->toRenderable();
+          $content_links = [];
+          foreach ($subtopic_ref_nodes as $content_node) {
+            /** @var \Drupal\node\NodeInterface $content_node */
+            $content_links[] = $content_node->toLink()->toRenderable();
+          }
         }
 
         // Add render array elements we can call from the node-topic--full template.


### PR DESCRIPTION
Now that content under subtopics can also reference articles and other subtopics we had to reshuffle how those lists were created. Where there isn't draggableviews data to determine the precise order of things to be returned we fall back to a query that unions articles and subtopics referencing a subtopic and use the results to generate the same result set for the lists we show.