### PR TITLE
DEPT-338 Banner images

### DIFF
--- a/config/sync/core.entity_view_display.node.heritage_site.full.yml
+++ b/config/sync/core.entity_view_display.node.heritage_site.full.yml
@@ -23,13 +23,15 @@ dependencies:
     - field.field.node.heritage_site.field_sm_number
     - field.field.node.heritage_site.field_town
     - field.field.node.heritage_site.field_website
+    - filter.format.plain_text
     - node.type.heritage_site
   module:
     - field_group
+    - geolocation
     - layout_builder
     - link
+    - metatag
     - options
-    - origins_common
     - text
     - user
 third_party_settings:
@@ -43,49 +45,32 @@ third_party_settings:
       parent_name: ''
       region: content
       weight: 6
-      format_type: details_sidebar
+      format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: true
+        open: false
         description: ''
         required_fields: false
-        weight: 0
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
     group_additional_info:
       children:
         - field_open_to_the_public
         - field_grid_reference
         - field_sm_number
         - field_nismr_link
-        - field_historic_map_viewer_link
       label: 'Additional Information'
       parent_name: ''
       region: content
       weight: 7
-      format_type: details_sidebar
+      format_type: details
       format_settings:
         classes: ''
         show_empty_fields: false
         id: ''
-        open: true
+        open: false
         description: ''
         required_fields: false
-        weight: 0
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
   layout_builder:
     enabled: false
     allow_custom: false
@@ -125,7 +110,7 @@ content:
     weight: 5
     region: content
   field_email:
-    type: email_mailto
+    type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
@@ -149,20 +134,95 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 9
     region: content
   field_map_location:
-    type: gmaps_lazy_load_formatter
-    label: hidden
+    type: geolocation_map
+    label: above
     settings:
-      map_type: roadmap
-      zoom: '15'
-      placeholder: empty
-      link_text: ''
-      map_width: '600'
-      map_height: '400'
+      set_marker: true
+      show_label: false
+      common_map: true
+      show_delta_label: false
+      use_overridden_map_settings: false
+      title: ''
+      info_text:
+        value: ''
+        format: plain_text
+      centre:
+        fit_bounds:
+          enable: true
+          weight: -101
+          settings:
+            reset_zoom: true
+            min_zoom: null
+          map_center_id: fit_bounds
+        fixed_boundaries:
+          enable: false
+          weight: 0
+          settings:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          map_center_id: fixed_boundaries
+        client_location:
+          enable: false
+          weight: 0
+          map_center_id: client_location
+        fixed_value:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: fixed_value
+            latitude: null
+            longitude: null
+          map_center_id: location_plugins
+        ipstack:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: ipstack
+            access_key: ''
+          map_center_id: location_plugins
+      map_provider_id: google_static_maps
+      map_provider_settings:
+        map_features:
+          geolocation_shapes:
+            weight: 0
+            settings:
+              remove_markers: false
+              polyline: true
+              polyline_title: ''
+              strokeColor: '#FF0000'
+              strokeOpacity: 0.8
+              strokeWidth: '2'
+              polygon: false
+              polygon_title: ''
+              fillColor: '#FF0000'
+              fillOpacity: 0.35
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+        type: ROADMAP
+        zoom: 10
+        height: null
+        width: null
+        format: png
+        scale: 1
+      data_provider_settings: {  }
     third_party_settings: {  }
-    weight: 9
+    weight: 13
+    region: content
+  field_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 12
     region: content
   field_nismr_link:
     type: link
@@ -239,7 +299,6 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
-  field_metatags: true
   field_site_subtopics: true
   field_site_topics: true
   groups: true

--- a/config/sync/migrate_plus.migration.node_landing_page.yml
+++ b/config/sync/migrate_plus.migration.node_landing_page.yml
@@ -84,6 +84,7 @@ process:
           -
             plugin: d7_file_lookup
             source: fid
+            entity_type: media
   field_banner_image_overlay:
     -
       plugin: sub_process

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_group_nodes/config/install/migrate_plus.migration.node_landing_page.yml
@@ -68,6 +68,7 @@ process:
         target_id:
           - plugin: d7_file_lookup
             source: fid
+            entity_type: media
   field_banner_image_overlay:
     - plugin: sub_process
       source: field_banner_image_overlay

--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -138,6 +138,9 @@ function dept_node_preprocess_node(array &$variables) {
     return;
   }
 
+  // Add the topic banner to the output, if relevant.
+  dept_node_topic_banner($variables);
+
   if ($view_mode === 'search_metadata' && $node->bundle() === 'news') {
     // Add the department metadata on the press-releases listing.
     if ($routename != 'view.news_search.press_release_search') {
@@ -196,4 +199,70 @@ function dept_node_preprocess_node(array &$variables) {
       '#weight' => count($variables['content']) + 1,
     ];
   }
+}
+
+/**
+ * Adds the required preprocess variables to the page
+ * if there is a parent topic with a landing page that has
+ * a banner image associated with it. If these values are
+ * detected at the template, it should render the image
+ * media with the overlay file on top to create a blended
+ * banner image that can appear above the title.
+ */
+function dept_node_topic_banner(array &$variables) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = &$variables['node'];
+  $view_mode = $variables['view_mode'];
+
+  // Only show the banner on full view mode.
+  if ($view_mode != 'full') {
+    return;
+  }
+
+  // Assume topic nodes present this banner as part of $content.
+  if ($node->bundle() === 'topic') {
+    return;
+  }
+
+  // Look up referenced topics.
+  $site_topics = NULL;
+  foreach (['field_site_topics', 'field_parent_topic'] as $topic_field_name) {
+    if ($node->hasField($topic_field_name)) {
+      $site_topics = $node->get($topic_field_name)->referencedEntities();
+    }
+  }
+
+  if (empty($site_topics)) {
+    return;
+  }
+
+  /** @var \Drupal\node\NodeInterface $topic_node */
+  $topic_node = $site_topics[0];
+
+  // Is there a landing page with the same topic reference with a banner?
+  $lp_query_ids = \Drupal::entityQuery('node')
+    ->condition('type', 'landing_page')
+    ->condition('status', 1)
+    ->condition('field_site_topics', $topic_node->id())
+    ->range(0, 1)
+    ->execute();
+
+  $landing_page_node = \Drupal::entityTypeManager()
+    ->getStorage('node')
+    ->loadMultiple($lp_query_ids);
+  $landing_page_node = reset($landing_page_node);
+
+  $banner_media = reset($landing_page_node
+    ->get('field_banner_image')
+    ->referencedEntities()
+  );
+
+  $banner_render = \Drupal::entityTypeManager()
+    ->getViewBuilder('media')
+    ->view($banner_media, 'banner_thin');
+
+  // Put the media render array into the preprocess vars to blend
+  // with the overlay image at the template layer.
+  $variables['banner_image'] = $banner_render;
+  $variables['banner_image']['#weight'] = -100;
 }


### PR DESCRIPTION
Takes the banner image media entity reference from a landing page node matching the same topic - subtopic nodes or those that use the parent topic field differ a little.

Produces a responsive image render element for the banner image in the thin banner style which can be fed into Twig templates as needed.