### PR TITLE
Dept 304 - block listing improvements for facets

### DIFF
--- a/config/sync/block.block.department.yml
+++ b/config/sync/block.block.department.yml
@@ -26,4 +26,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: /press-releases
+    pages: "/press-releases\r\n/press-releases*"

--- a/config/sync/block.block.prpublicationdate.yml
+++ b/config/sync/block.block.prpublicationdate.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - facets.facet.pr_publication_date
   module:
-    - domain
     - facets
     - system
   theme:
@@ -24,14 +23,7 @@ settings:
   context_mapping: {  }
   block_id: prpublicationdate
 visibility:
-  domain:
-    id: domain
-    negate: false
-    context_mapping:
-      domain: '@domain.current_domain_context:domain'
-    domains:
-      group_1: group_1
   request_path:
     id: request_path
     negate: false
-    pages: /press-releases
+    pages: "/press-releases\r\n/press-releases*"

--- a/config/sync/block.block.prtopics.yml
+++ b/config/sync/block.block.prtopics.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - facets.facet.pr_topics
   module:
-    - domain
     - facets
     - system
   theme:
@@ -24,14 +23,7 @@ settings:
   context_mapping: {  }
   block_id: prtopics
 visibility:
-  domain:
-    id: domain
-    negate: false
-    context_mapping:
-      domain: '@domain.current_domain_context:domain'
-    domains:
-      group_1: group_1
   request_path:
     id: request_path
     negate: false
-    pages: /press-releases
+    pages: "/press-releases\r\n/press-releases*"

--- a/config/sync/facets.facet.pr_department.yml
+++ b/config/sync/facets.facet.pr_department.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: pr_department
-name: 'PR: Department'
+name: 'Department'
 weight: 0
 min_count: 1
 missing: false

--- a/config/sync/facets.facet.pr_publication_date.yml
+++ b/config/sync/facets.facet.pr_publication_date.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: pr_publication_date
-name: 'PR: Publication date'
+name: 'Publication date'
 weight: 0
 min_count: 1
 missing: false

--- a/config/sync/facets.facet.pr_topics.yml
+++ b/config/sync/facets.facet.pr_topics.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - search_api
 id: pr_topics
-name: 'pr: topics'
+name: 'Topics'
 weight: 0
 min_count: 1
 missing: false

--- a/web/modules/custom/dept_search/dept_search.module
+++ b/web/modules/custom/dept_search/dept_search.module
@@ -5,6 +5,7 @@
  * Search related overrides and preprocessing.
  */
 
+use Drupal\block\Entity\Block;
 use Drupal\dept_core\Entity\Department;
 use Drupal\facets\FacetInterface;
 use Drupal\views\ViewExecutable;
@@ -39,7 +40,6 @@ function dept_search_preprocess_facets_summary_item_list(&$variables) {
  * Implements hook_preprocess_facets_item_list().
  */
 function dept_search_preprocess_facets_item_list(array &$variables) {
-
   /** @var \Drupal\facets\FacetInterface $facet */
   $facet = $variables['facet'];
 
@@ -143,4 +143,41 @@ function dept_search_views_data_alter(array &$data) {
     ],
   ];
   return $data;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function dept_search_form_block_admin_display_form_alter(&$form) {
+  foreach ($form['blocks'] as $block_id => $block_info) {
+    if (preg_match('/^#/', $block_id)) {
+      // It's a render attribute so skip it.
+      continue;
+    }
+
+    $type = $block_info['type']['#markup'] ?? '';
+
+    if (preg_match('/facets/i', $type)) {
+      /** @var \Drupal\block\BlockInterface $block */
+      $block = Block::load($block_id);
+      $settings = $block->get('settings');
+
+      if (empty($settings)) {
+        return;
+      }
+
+      $facet_id = str_replace('facet_block:', '', $settings['id']);
+      /** @var \Drupal\facets\Entity\Facet $facet */
+      $facet = \Drupal::entityTypeManager()->getStorage('facets_facet')->load($facet_id);
+
+      if ($facet instanceof FacetInterface) {
+        /** @var \Drupal\facets\Plugin\facets\facet_source\SearchApiDisplay $source */
+        $source = $facet->getFacetSource();
+
+        $view_title = $source->getViewsDisplay()->getTitle();
+        // It's a facet block so we can adjust the title string.
+        $form['blocks'][$block_id]['info']['#plain_text'] .= ' (facet view: ' . $view_title . ')';
+      }
+    }
+  }
 }


### PR DESCRIPTION
Introduces:

* Block layout page change so that facet blocks now indicate which view they're associated with:

![image](https://user-images.githubusercontent.com/451261/220400017-9d2c642c-f278-4732-a105-3f302f2b8d95.png)

* Review of Solr config files to confirm group related fields are no longer being added to Solr documents.