### PR TITLE
DEPT 328 structured address fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -231,6 +231,9 @@
             ]
         },
         "patches": {
+            "drupal/address": {
+                "Allow to set a list of preferred countries": "https://www.drupal.org/files/issues/2023-01-06/2626982-45.preferred_countries.patch"
+            },
             "drupal/core": {
                 "Prevent leftover fields from causing errors like 'Call to a member function getLabel() after enabling layout_builder'": "https://www.drupal.org/files/issues/2020-01-20/2985882-53.patch",
                 "Render blocks in preview page": "https://www.drupal.org/files/issues/2019-10-03/3085364_2.patch",

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "dof-dss/nicsdru_nidirect_theme": "*",
         "dof-dss/nicsdru_origins_modules": "^2.0",
         "dof-dss/nicsdru_origins_theme": "^0.4.0",
+        "drupal/address": "^1.11",
         "drupal/admin_toolbar": "^3.3",
         "drupal/adminimal_theme": "^1.6",
         "drupal/antibot": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d193939672c5f692c72e7b9bc252addb",
+    "content-hash": "9069a5ef5a08a87ffd1f178fe054d9b3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -17943,5 +17943,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9e6b4aeb2cf1b4fbb997a978c202d17",
+    "content-hash": "9069a5ef5a08a87ffd1f178fe054d9b3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -183,6 +183,70 @@
                 "source": "https://github.com/Chi-teck/drupal-code-generator/tree/2.6.2"
             },
             "time": "2022-11-11T15:34:04+00:00"
+        },
+        {
+            "name": "commerceguys/addressing",
+            "version": "v1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/addressing.git",
+                "reference": "406c7b5f0fbe4f6a64155c0fe03b1adb34d01308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/406c7b5f0fbe4f6a64155c0fe03b1adb34d01308",
+                "reference": "406c7b5f0fbe4f6a64155c0fe03b1adb34d01308",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/collections": "^1.2 || ^2.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "mikey179/vfsstream": "^1.6.10",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/validator": "^4.4 || ^5.4 || ^6.0"
+            },
+            "suggest": {
+                "symfony/validator": "to validate addresses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Addressing\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                },
+                {
+                    "name": "Damien Tournoud"
+                }
+            ],
+            "description": "Addressing library powered by CLDR and Google's address data.",
+            "keywords": [
+                "address",
+                "internationalization",
+                "localization",
+                "postal"
+            ],
+            "support": {
+                "issues": "https://github.com/commerceguys/addressing/issues",
+                "source": "https://github.com/commerceguys/addressing/tree/v1.4.2"
+            },
+            "time": "2023-02-15T10:11:14+00:00"
         },
         {
             "name": "composer/installers",
@@ -2068,6 +2132,79 @@
                 "source": "https://github.com/dof-dss/nicsdru_origins_theme/tree/0.4.5"
             },
             "time": "2023-01-11T11:00:48+00:00"
+        },
+        {
+            "name": "drupal/address",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/address.git",
+                "reference": "8.x-1.11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/address-8.x-1.11.zip",
+                "reference": "8.x-1.11",
+                "shasum": "1cb40fb1a43e88041b888ac8fb6aa77a45ac85fb"
+            },
+            "require": {
+                "commerceguys/addressing": "^1.4.0",
+                "drupal/core": "^9.2 || ^10",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "drupal/token": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.11",
+                    "datestamp": "1659989858",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bojanz",
+                    "homepage": "https://www.drupal.org/user/86106"
+                },
+                {
+                    "name": "Centarro",
+                    "homepage": "https://www.drupal.org/user/3661446"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "googletorp",
+                    "homepage": "https://www.drupal.org/user/386230"
+                },
+                {
+                    "name": "jsacksick",
+                    "homepage": "https://www.drupal.org/user/972218"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
+                },
+                {
+                    "name": "rszrama",
+                    "homepage": "https://www.drupal.org/user/49344"
+                }
+            ],
+            "description": "Provides functionality for storing, validating and displaying international postal addresses.",
+            "homepage": "http://drupal.org/project/address",
+            "support": {
+                "source": "https://git.drupalcode.org/project/address"
+            }
         },
         {
             "name": "drupal/admin_toolbar",
@@ -17806,5 +17943,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9069a5ef5a08a87ffd1f178fe054d9b3",
+    "content-hash": "065a2d2b432be65d4cf4d7967bec6997",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3560,6 +3560,10 @@
                     "name": "Brian Gilbert (realityloop).",
                     "homepage": "https://www.drupal.org/u/realityloop",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "lhangea",
+                    "homepage": "https://www.drupal.org/user/2743803"
                 },
                 {
                     "name": "miro_dietiker",

--- a/config/sync/core.entity_form_display.department.department.default.yml
+++ b/config/sync/core.entity_form_display.department.department.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.department.department.field_dept_social_media_links
   module:
     - dept_core
-    - geolocation
+    - geolocation_google_maps
     - link
     - text
 id: department.department.default
@@ -60,10 +60,308 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_dept_location:
-    type: geolocation_latlng
+    type: geolocation_googlegeocoder
     weight: 29
     region: content
-    settings: {  }
+    settings:
+      auto_client_location: ''
+      auto_client_location_marker: '0'
+      allow_override_map_settings: 0
+      hide_textfield_form: false
+      centre:
+        ipstack:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: ipstack
+            access_key: ''
+          map_center_id: location_plugins
+        fixed_value:
+          enable: false
+          weight: 0
+          settings:
+            location_option_id: fixed_value
+            latitude: null
+            longitude: null
+          map_center_id: location_plugins
+        client_location:
+          enable: false
+          weight: 0
+          map_center_id: client_location
+        fit_bounds:
+          enable: true
+          weight: 0
+          settings:
+            reset_zoom: false
+            min_zoom: null
+          map_center_id: fit_bounds
+        fixed_boundaries:
+          enable: false
+          weight: 0
+          settings:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          map_center_id: fixed_boundaries
+      google_map_settings:
+        map_features:
+          control_geocoder:
+            weight: -100
+            settings:
+              position: TOP_LEFT
+              geocoder: google_geocoding_api
+              settings:
+                label: Address
+                description: 'Enter an address to be localized.'
+                autocomplete_min_length: 1
+                component_restrictions:
+                  route: ''
+                  country: UK
+                  administrative_area: ''
+                  locality: ''
+                  postal_code: ''
+                boundary_restriction:
+                  south: ''
+                  west: ''
+                  north: ''
+                  east: ''
+                region: ''
+            enabled: true
+          google_maps_layer_bicycling:
+            weight: 0
+            enabled: false
+          client_location_indicator:
+            weight: 0
+            enabled: false
+          context_popup:
+            weight: 0
+            settings:
+              content:
+                value: ''
+                format: basic_html
+            enabled: false
+          drawing:
+            weight: 0
+            settings:
+              polyline: false
+              strokeColor: '#FF0000'
+              strokeOpacity: '0.8'
+              strokeWeight: '2'
+              geodesic: false
+              polygon: false
+              fillColor: '#FF0000'
+              fillOpacity: '0.35'
+            enabled: false
+          geolocation_google_maps_control_directions:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+              origin_source: exposed
+              origin_static_value: ''
+              destination_source: exposed
+              destination_static_value: ''
+              travel_mode: exposed
+              directions_container: below
+              directions_container_custom_id: ''
+            enabled: false
+          map_disable_tilt:
+            weight: 0
+            enabled: false
+          map_disable_poi:
+            weight: 0
+            enabled: false
+          map_disable_user_interaction:
+            weight: 0
+            enabled: false
+          geolocation_shapes:
+            weight: 0
+            settings:
+              remove_markers: false
+              polyline: true
+              polyline_title: ''
+              strokeColor: '#FF0000'
+              strokeOpacity: 0.8
+              strokeWidth: '2'
+              polygon: false
+              polygon_title: ''
+              fillColor: '#FF0000'
+              fillOpacity: 0.35
+            enabled: false
+          control_fullscreen:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+            enabled: false
+          control_loading_indicator:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+              loading_label: Loading
+            enabled: false
+          control_locate:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+            enabled: true
+          control_maptype:
+            weight: 0
+            settings:
+              position: RIGHT_BOTTOM
+              behavior: default
+              style: DEFAULT
+            enabled: true
+          control_recenter:
+            weight: 0
+            settings:
+              position: TOP_LEFT
+            enabled: true
+          control_rotate:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+            enabled: false
+          control_streetview:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+            enabled: false
+          control_zoom:
+            weight: 0
+            settings:
+              position: RIGHT_CENTER
+              behavior: default
+              style: LARGE
+            enabled: true
+          map_restriction:
+            weight: 0
+            settings:
+              north: ''
+              south: ''
+              east: ''
+              west: ''
+              strict: true
+            enabled: false
+          map_type_style:
+            weight: 0
+            settings:
+              style: '[]'
+            enabled: false
+          marker_clusterer:
+            weight: 0
+            settings:
+              image_path: ''
+              styles: ''
+              max_zoom: 15
+              minimum_cluster_size: 2
+              zoom_on_click: true
+              average_center: false
+              grid_size: 60
+            enabled: false
+          marker_icon:
+            weight: 0
+            settings:
+              marker_icon_path: ''
+              anchor:
+                x: 0
+                'y': 0
+              origin:
+                x: 0
+                'y': 0
+              label_origin:
+                x: 0
+                'y': 0
+              size:
+                width: null
+                height: null
+              scaled_size:
+                width: null
+                height: null
+            enabled: false
+          marker_infobubble:
+            weight: 0
+            settings:
+              close_other: 1
+              close_button: 0
+              close_button_src: ''
+              shadow_style: 0
+              padding: 10
+              border_radius: 8
+              border_width: 2
+              border_color: '#039be5'
+              background_color: '#fff'
+              min_width: null
+              max_width: 550
+              min_height: null
+              max_height: null
+              arrow_style: 2
+              arrow_position: 30
+              arrow_size: 10
+            enabled: false
+          marker_infowindow:
+            weight: 0
+            settings:
+              info_window_solitary: true
+              disable_auto_pan: true
+              info_auto_display: false
+              max_width: null
+            enabled: true
+          marker_label:
+            weight: 0
+            settings:
+              color: ''
+              font_family: ''
+              font_size: ''
+              font_weight: ''
+            enabled: false
+          marker_opacity:
+            weight: 0
+            settings:
+              opacity: !!float 1
+            enabled: false
+          geolocation_marker_scroll_to_id:
+            weight: 0
+            settings:
+              scroll_target_id: ''
+            enabled: false
+          marker_zoom_to_animate:
+            weight: 0
+            settings:
+              marker_zoom_anchor_id: ''
+            enabled: false
+          spiderfying:
+            weight: 0
+            settings:
+              spiderfiable_marker_path: /modules/contrib/geolocation/modules/geolocation_google_maps/images/marker-plus.svg
+              markersWontMove: true
+              markersWontHide: false
+              keepSpiderfied: true
+              ignoreMapClick: false
+              nearbyDistance: 20
+              circleSpiralSwitchover: 9
+              circleFootSeparation: 23
+              spiralFootSeparation: 26
+              spiralLengthStart: 11
+              spiralLengthFactor: 4
+              legWeight: 1.5
+            enabled: false
+          google_maps_layer_traffic:
+            weight: 0
+            enabled: false
+          google_maps_layer_transit:
+            weight: 0
+            enabled: false
+        type: ROADMAP
+        zoom: 14
+        minZoom: 0
+        maxZoom: 20
+        height: 400px
+        width: 100%
+        gestureHandling: auto
     third_party_settings: {  }
   field_dept_management_structure:
     type: text_textarea_with_summary

--- a/config/sync/core.entity_form_display.node.heritage_site.default.yml
+++ b/config/sync/core.entity_form_display.node.heritage_site.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.heritage_site.body
+    - field.field.node.heritage_site.field_address
     - field.field.node.heritage_site.field_address_line_1
     - field.field.node.heritage_site.field_address_line_2
     - field.field.node.heritage_site.field_county
@@ -28,9 +29,11 @@ dependencies:
     - node.type.heritage_site
     - workflows.workflow.nics_editorial_workflow
   module:
+    - address
     - chosen_field
     - content_moderation
     - field_group
+    - geolocation_address
     - geolocation_google_maps
     - link
     - media_library
@@ -44,12 +47,13 @@ third_party_settings:
       children:
         - field_address_line_1
         - field_address_line_2
-        - field_town
+        - field_county
         - field_postcode
-      label: Address
-      region: content
+        - field_town
+      label: 'LEGACY Address'
+      region: hidden
       parent_name: ''
-      weight: 3
+      weight: 24
       format_type: details
       format_settings:
         classes: ''
@@ -115,44 +119,29 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_address_line_1:
-    type: string_textfield
-    weight: 4
+  field_address:
+    type: address_default
+    weight: 3
     region: content
     settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_address_line_2:
-    type: string_textfield
-    weight: 5
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_county:
-    type: options_select
-    weight: 4
-    region: content
-    settings: {  }
+      preferred_countries: {  }
     third_party_settings: {  }
   field_domain_access:
     type: options_buttons
-    weight: 40
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   field_domain_all_affiliates:
     type: boolean_checkbox
-    weight: 41
+    weight: 22
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_domain_source:
     type: options_select
-    weight: 42
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -182,7 +171,7 @@ content:
     third_party_settings: {  }
   field_map_location:
     type: geolocation_googlegeocoder
-    weight: 29
+    weight: 4
     region: content
     settings:
       auto_client_location: ''
@@ -248,7 +237,7 @@ content:
                   north: ''
                   east: ''
                 region: ''
-            enabled: true
+            enabled: false
           google_maps_layer_bicycling:
             weight: 0
             enabled: false
@@ -483,10 +472,40 @@ content:
         height: 400px
         width: 100%
         gestureHandling: auto
-    third_party_settings: {  }
+    third_party_settings:
+      geolocation_address:
+        enable: true
+        address_field: field_address
+        geocoder: google_geocoding_api
+        settings:
+          label: Address
+          description: 'Enter an address to be localized.'
+          autocomplete_min_length: 1
+          component_restrictions:
+            route: ''
+            country: 'UK, IE'
+            administrative_area: ''
+            locality: ''
+            postal_code: ''
+          boundary_restriction:
+            south: ''
+            west: ''
+            north: ''
+            east: ''
+          region: ''
+        sync_mode: auto
+        button_position: LEFT_TOP
+        direction: duplex
+        ignore:
+          organization: false
+          address-line1: false
+          address-line2: false
+          locality: false
+          administrative-area: false
+          postal-code: false
   field_metatags:
     type: metatag_firehose
-    weight: 28
+    weight: 20
     region: content
     settings:
       sidebar: true
@@ -521,14 +540,6 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
-  field_postcode:
-    type: string_textfield
-    weight: 7
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_site_subtopics:
     type: chosen_select
     weight: 2
@@ -544,14 +555,6 @@ content:
   field_sm_number:
     type: string_textfield
     weight: 12
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_town:
-    type: string_textfield
-    weight: 6
     region: content
     settings:
       size: 60
@@ -579,26 +582,26 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 21
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 13
+    weight: 12
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -610,14 +613,14 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 22
+    weight: 19
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 14
+    weight: 13
     region: content
     settings:
       display_label: true
@@ -642,7 +645,7 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -653,14 +656,16 @@ content:
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 20
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   entitygroupfield: true
-  field_domain_access: true
-  field_domain_all_affiliates: true
-  field_domain_source: true
+  field_address_line_1: true
+  field_address_line_2: true
+  field_county: true
   field_map: true
+  field_postcode: true
+  field_town: true
   groups: true

--- a/config/sync/core.entity_form_display.node.heritage_site.default.yml
+++ b/config/sync/core.entity_form_display.node.heritage_site.default.yml
@@ -53,7 +53,7 @@ third_party_settings:
       label: 'LEGACY Address'
       region: hidden
       parent_name: ''
-      weight: 24
+      weight: 25
       format_type: details
       format_settings:
         classes: ''
@@ -70,7 +70,7 @@ third_party_settings:
       label: Contact
       region: content
       parent_name: ''
-      weight: 5
+      weight: 6
       format_type: details
       format_settings:
         classes: ''
@@ -89,7 +89,23 @@ third_party_settings:
       label: 'Additional Information'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 7
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_address_details:
+      children:
+        - field_address
+        - field_map_location
+      label: 'Address details'
+      region: content
+      parent_name: ''
+      weight: 3
       format_type: details
       format_settings:
         classes: ''
@@ -105,7 +121,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 8
+    weight: 9
     region: content
     settings:
       rows: 9
@@ -115,33 +131,33 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   field_address:
     type: address_default
-    weight: 3
+    weight: 4
     region: content
     settings:
       preferred_countries: {  }
     third_party_settings: {  }
   field_domain_access:
     type: options_buttons
-    weight: 21
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
   field_domain_all_affiliates:
     type: boolean_checkbox
-    weight: 22
+    weight: 23
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_domain_source:
     type: options_select
-    weight: 23
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -171,7 +187,7 @@ content:
     third_party_settings: {  }
   field_map_location:
     type: geolocation_googlegeocoder
-    weight: 4
+    weight: 5
     region: content
     settings:
       auto_client_location: ''
@@ -505,7 +521,7 @@ content:
           postal-code: false
   field_metatags:
     type: metatag_firehose
-    weight: 20
+    weight: 21
     region: content
     settings:
       sidebar: true
@@ -535,7 +551,7 @@ content:
     third_party_settings: {  }
   field_photo:
     type: media_library_widget
-    weight: 7
+    weight: 8
     region: content
     settings:
       media_types: {  }
@@ -575,33 +591,33 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 9
+    weight: 10
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 12
+    weight: 13
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -613,14 +629,14 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 19
+    weight: 20
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
@@ -635,7 +651,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 10
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -645,7 +661,7 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -656,7 +672,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.heritage_site.default.yml
+++ b/config/sync/core.entity_view_display.node.heritage_site.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.heritage_site.body
+    - field.field.node.heritage_site.field_address
     - field.field.node.heritage_site.field_address_line_1
     - field.field.node.heritage_site.field_address_line_2
     - field.field.node.heritage_site.field_county
@@ -27,6 +28,7 @@ dependencies:
     - field.field.node.heritage_site.field_website
     - node.type.heritage_site
   module:
+    - address
     - field_group
     - link
     - metatag
@@ -82,6 +84,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_address:
+    type: address_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 14
     region: content
   field_address_line_1:
     type: string

--- a/config/sync/core.entity_view_display.node.heritage_site.full.yml
+++ b/config/sync/core.entity_view_display.node.heritage_site.full.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.heritage_site.body
+    - field.field.node.heritage_site.field_address
     - field.field.node.heritage_site.field_address_line_1
     - field.field.node.heritage_site.field_address_line_2
     - field.field.node.heritage_site.field_county
@@ -225,6 +226,7 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
+  field_address: true
   field_domain_access: true
   field_domain_all_affiliates: true
   field_domain_source: true

--- a/config/sync/core.entity_view_display.node.heritage_site.teaser.yml
+++ b/config/sync/core.entity_view_display.node.heritage_site.teaser.yml
@@ -5,9 +5,13 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.heritage_site.body
+    - field.field.node.heritage_site.field_address
     - field.field.node.heritage_site.field_address_line_1
     - field.field.node.heritage_site.field_address_line_2
     - field.field.node.heritage_site.field_county
+    - field.field.node.heritage_site.field_domain_access
+    - field.field.node.heritage_site.field_domain_all_affiliates
+    - field.field.node.heritage_site.field_domain_source
     - field.field.node.heritage_site.field_email
     - field.field.node.heritage_site.field_grid_reference
     - field.field.node.heritage_site.field_historic_map_viewer_link
@@ -48,6 +52,7 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
+  field_address: true
   field_address_line_1: true
   field_address_line_2: true
   field_county: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
 module:
+  address: 0
   admin_toolbar: 0
   admin_toolbar_tools: 0
   antibot: 0
@@ -77,6 +78,7 @@ module:
   filter: 0
   flag: 0
   geolocation: 0
+  geolocation_address: 0
   geolocation_google_maps: 0
   geolocation_google_static_maps: 0
   google_map_field: 0

--- a/config/sync/field.field.node.heritage_site.field_address.yml
+++ b/config/sync/field.field.node.heritage_site.field_address.yml
@@ -1,0 +1,61 @@
+uuid: 148c576b-d4c0-4e9e-8a6c-2ce4054ada94
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_address
+    - node.type.heritage_site
+  module:
+    - address
+id: node.heritage_site.field_address
+field_name: field_address
+entity_type: node
+bundle: heritage_site
+label: Address
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    langcode: null
+    country_code: GB
+    administrative_area: null
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: ''
+    organization: null
+    given_name: null
+    additional_name: null
+    family_name: null
+default_value_callback: ''
+settings:
+  available_countries:
+    IE: IE
+    GB: GB
+  langcode_override: ''
+  field_overrides:
+    givenName:
+      override: hidden
+    additionalName:
+      override: hidden
+    familyName:
+      override: hidden
+    organization:
+      override: hidden
+    addressLine1:
+      override: optional
+    addressLine2:
+      override: optional
+    sortingCode:
+      override: optional
+    dependentLocality:
+      override: optional
+    locality:
+      override: optional
+    administrativeArea:
+      override: optional
+  fields: {  }
+field_type: address

--- a/config/sync/field.storage.node.field_address.yml
+++ b/config/sync/field.storage.node.field_address.yml
@@ -1,0 +1,19 @@
+uuid: 2789d864-4605-4cde-88de-9cf58659638a
+langcode: en
+status: true
+dependencies:
+  module:
+    - address
+    - node
+id: node.field_address
+field_name: field_address
+entity_type: node
+type: address
+settings: {  }
+module: address
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/migrate_plus.migration.node_heritage_site.yml
+++ b/config/sync/migrate_plus.migration.node_heritage_site.yml
@@ -1,9 +1,7 @@
-uuid: fc2ba1d1-c1e8-4080-a12d-c9109356a93b
+uuid: 92a17860-1c36-41e2-b4f3-30c226be046a
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: a_-GKEfAlGpB0JfwaUlAGgPxvpvSwBoAza82Po4Soms
 id: node_heritage_site
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: alterFieldInstanceMigration
@@ -77,6 +75,23 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
+  field_address:
+    -
+      plugin: callback
+      callable:
+        - \Drupal\dept_migrate\AddressFieldMerge
+        - convertToAddressFieldFormat
+      source:
+        - field_address_line_1
+        - field_address_line_2
+        - ''
+        - ''
+        - ''
+        - field_county
+        - field_town
+        - field_postcode
+    -
+      plugin: addressfield
   field_address_line_1: field_address_line_1
   field_address_line_2: field_address_line_2
   field_town: field_town

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
@@ -61,6 +61,21 @@ process:
         html_for_admins: full_html
         paste_format: plain_text
         plain_text: plain_text
+  field_address:
+    - plugin: callback
+      callable:
+        - '\Drupal\dept_migrate\AddressFieldMerge'
+        - convertToAddressFieldFormat
+      source:
+        - field_address_line_1
+        - field_address_line_2
+        - ''
+        - ''
+        - ''
+        - field_county
+        - field_town
+        - field_postcode
+    - plugin: addressfield
   field_address_line_1: field_address_line_1
   field_address_line_2: field_address_line_2
   field_town: field_town

--- a/web/modules/custom/dept_migrate/src/AddressFieldMerge.php
+++ b/web/modules/custom/dept_migrate/src/AddressFieldMerge.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\dept_migrate;
+
+/**
+ * Class AddressFieldMerge.
+ *
+ * Gathers arbitary address fragments and assembles into array
+ * that AddressField migrate process plugin can understand and work with.
+ */
+class AddressFieldMerge {
+
+  /**
+   * Transform to adddressfield array.
+   *
+   * Take an array of address fragments (opinionated) and
+   * return a structured addressfield plugin array.
+   *
+   * @param array $addressFragments
+   *   Order matters:
+   *   - Address line 1.
+   *   - Address line 2.
+   *   - Address line 3.
+   *   - Address line 4.
+   *   - Address line 5.
+   *   - Administrative area/county.
+   *   - Town/city.
+   *   - Postal code.
+   *   - Country code.
+   *
+   * @return array
+   *   Array of keyed data for use with the addressfield process plugin.
+   */
+  public static function convertToAddressFieldFormat(array $addressFragments) {
+
+    // Flatten down/extract any contained array values.
+    for ($i = 0; $i < count($addressFragments); $i++) {
+      if (empty($addressFragments[$i])) {
+        $addressFragments[$i] = '';
+      }
+
+      if (is_array($addressFragments[$i])) {
+        $addressFragments[$i] = array_pop($addressFragments[$i])['value'];
+      }
+    }
+
+    $address_line1 = $addressFragments[0];
+    $address_line2 = $addressFragments[1];
+    $address_line3 = $addressFragments[2];
+    $address_line4 = $addressFragments[3];
+    $address_line5 = $addressFragments[4];
+    $admin_area_county = $addressFragments[5];
+    $town_city = $addressFragments[6];
+    $postal_code = $addressFragments[7];
+    $country_code = empty($addressFragments[8]) ? 'GB' : $addressFragments[8];
+
+    // Flatten ambiguous address fields:
+    // Always merge together address lines 1 and 2.
+    $flattened_addressline1 = '';
+    $flattened_addressline1 = $address_line1;
+    if (!empty($address_line2)) {
+      $flattened_addressline1 .= ', ' . $address_line2;
+    }
+
+    if (strlen($flattened_addressline1) >= 255) {
+      $flattened_addressline1 = substr($flattened_addressline1, 0, 255);
+    }
+
+    // ... and 3, 4 and 5.
+    $flattened_addressline2 = '';
+    if (!empty($address_line3)) {
+      $flattened_addressline2 = $address_line3;
+    }
+    if (!empty($address_line4)) {
+      $flattened_addressline2 .= ', ' . $address_line4;
+    }
+    if (!empty($address_line5)) {
+      $flattened_addressline2 .= ', ' . $address_line5;
+    }
+
+    if (strlen($flattened_addressline2) >= 255) {
+      $flattened_addressline2 = substr($flattened_addressline2, 0, 255);
+    }
+
+    // Array labels mimic the D7 addressfield values.
+    // See Drupal\address\Plugin\migrate\process\AddressField::transform().
+    $address_data = [
+      'country' => $country_code,
+      'administrative_area' => $admin_area_county,
+      'locality' => $town_city,
+      'dependent_locality' => '',
+      'postal_code' => $postal_code,
+      'thoroughfare' => $flattened_addressline1,
+      'premise' => $flattened_addressline2,
+      'organisation_name' => '',
+    ];
+
+    return $address_data;
+  }
+
+}


### PR DESCRIPTION
* Moves the legacy address field out of sight on the editorial forms but retained for reference if needed in future.
* Replaces the text fields for address parts with a proper address component.
* Integration with geolocation module for accurate and simple geocoding.
* Map widget for address disabled on heritage site, users encouraged to populate the address component fields. Clicking a point on the map geocodes the nearest known address and populates the address component (two-way sync)