### PR TITLE
niexec home page: move Budget and PfG blocks 

### DIFF
--- a/config/sync/block.block.departmental_details_social_links.yml
+++ b/config/sync/block.block.departmental_details_social_links.yml
@@ -11,7 +11,7 @@ dependencies:
 id: departmental_details_social_links
 theme: nicsdru_dept_theme
 region: content
-weight: -17
+weight: -18
 provider: null
 plugin: dept_core_departmental_details
 settings:

--- a/config/sync/block.block.departmentaldetails_2.yml
+++ b/config/sync/block.block.departmentaldetails_2.yml
@@ -10,7 +10,7 @@ dependencies:
 id: departmentaldetails_2
 theme: nicsdru_dept_theme
 region: content
-weight: -22
+weight: -23
 provider: null
 plugin: dept_core_departmental_details
 settings:

--- a/config/sync/block.block.departmentaldetails_6.yml
+++ b/config/sync/block.block.departmentaldetails_6.yml
@@ -10,7 +10,7 @@ dependencies:
 id: departmentaldetails_6
 theme: nicsdru_dept_theme
 region: content
-weight: -21
+weight: -22
 provider: null
 plugin: dept_core_departmental_details
 settings:

--- a/config/sync/block.block.mainpagecontent.yml
+++ b/config/sync/block.block.mainpagecontent.yml
@@ -9,7 +9,7 @@ dependencies:
 id: mainpagecontent
 theme: nicsdru_dept_theme
 region: content
-weight: -20
+weight: -21
 provider: null
 plugin: system_main_block
 settings:

--- a/config/sync/block.block.niexec_featured_topics.yml
+++ b/config/sync/block.block.niexec_featured_topics.yml
@@ -1,0 +1,38 @@
+uuid: 10d97e57-4416-4e6c-8f4e-ba96010627a2
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:block_group:4e9b2662-00ce-4467-90cb-ce9e13b9101d'
+  module:
+    - block_content
+    - domain
+    - system
+  theme:
+    - nicsdru_dept_theme
+id: niexec_featured_topics
+theme: nicsdru_dept_theme
+region: content
+weight: -16
+provider: null
+plugin: 'block_content:4e9b2662-00ce-4467-90cb-ce9e13b9101d'
+settings:
+  id: 'block_content:4e9b2662-00ce-4467-90cb-ce9e13b9101d'
+  label: 'niexec: featured topics'
+  label_display: '0'
+  provider: block_content
+  status: true
+  info: ''
+  view_mode: full
+visibility:
+  domain:
+    id: domain
+    negate: false
+    context_mapping:
+      domain: '@domain.current_domain_context:domain'
+    domains:
+      nigov: nigov
+  request_path:
+    id: request_path
+    negate: false
+    pages: '<front>'

--- a/config/sync/block.block.views_block__links_block_quick_links.yml
+++ b/config/sync/block.block.views_block__links_block_quick_links.yml
@@ -13,7 +13,7 @@ dependencies:
 id: views_block__links_block_quick_links
 theme: nicsdru_dept_theme
 region: content
-weight: -18
+weight: -19
 provider: null
 plugin: 'views_block:links-block_quick_links'
 settings:

--- a/config/sync/block.block.views_block__news_block_all_depts_latest_press_releases.yml
+++ b/config/sync/block.block.views_block__news_block_all_depts_latest_press_releases.yml
@@ -13,7 +13,7 @@ dependencies:
 id: views_block__news_block_all_depts_latest_press_releases
 theme: nicsdru_dept_theme
 region: content
-weight: -19
+weight: -20
 provider: null
 plugin: 'views_block:news-block_all_depts_latest_press_releases'
 settings:

--- a/config/sync/block.block.views_block__topic_queue_block_topics_queue.yml
+++ b/config/sync/block.block.views_block__topic_queue_block_topics_queue.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__topic_queue_block_topics_queue
 theme: nicsdru_dept_theme
 region: content
-weight: -16
+weight: -17
 provider: null
 plugin: 'views_block:topic_queue-block_topics_queue'
 settings:

--- a/config/sync/field.field.block_content.block_group.field_blocks.yml
+++ b/config/sync/field.field.block_content.block_group.field_blocks.yml
@@ -13,7 +13,7 @@ entity_type: block_content
 bundle: block_group
 label: blocks
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
@@ -30,7 +30,6 @@ settings:
       'Custom menu link fields': 'Custom menu link fields'
       'Departmental sites': 'Departmental sites'
       'Department fields': 'Department fields'
-      'Department Homepage': 'Department Homepage'
       Devel: Devel
       Development: Development
       Domain: Domain

--- a/config/sync/structure_sync.data.yml
+++ b/config/sync/structure_sync.data.yml
@@ -1,34 +1,8 @@
 blocks:
   -
-    info: 'niexec: pfg'
+    info: 'niexec: featured topics'
     langcode: en
-    uuid: ccc0d53e-810b-40c0-a368-2de586eb7771
-    bundle: basic
-    revision_id: null
-    rev_id_current: null
-    fields:
-      body:
-        -
-          value: "<h3>Programme for Government</h3>\r\n<div class=\"card card--no-border card--no-padding\">\r\n\r\n<div class=\"card__image\">\r\n<drupal-media data-align=\"center\" data-entity-type=\"media\" data-entity-uuid=\"397bdb06-afa6-421e-8d23-911d10fd9f49\" data-view-mode=\"feature_card\"></drupal-media>\r\n</div>\r\n\r\n<div class=\"card__body\">\r\n<p>The Programme for Government (PfG) sets the strategic context for both the Budget and the Investment Strategy for Northern Ireland.</p>\r\n\r\n<p><a href=\"/node/152663\">Find out more about the PfG</a></p>\r\n</div>\r\n</div>\r\n"
-          summary: ''
-          format: full_html
-  -
-    info: 'niexec: budget'
-    langcode: en
-    uuid: bab5e511-c70f-40d0-9539-a9a1b00d909e
-    bundle: basic
-    revision_id: null
-    rev_id_current: null
-    fields:
-      body:
-        -
-          value: "<h3>Budget</h3>\r\n<div class=\"card card--no-border card--no-padding\">\r\n\r\n<div class=\"card__image\">\r\n<drupal-media data-align=\"center\" data-entity-type=\"media\" data-entity-uuid=\"52143c3d-ca63-4bc0-95ab-36bbefcfd6d2\" data-view-mode=\"feature_card\"></drupal-media>\r\n</div>\r\n\r\n<div class=\"card__body\">\r\n<p>The Budget provides the Executive with an opportunity to improve the lives of people in Northern Ireland by allocating resources to high priority areas.</p>\r\n\r\n<p><a href=\"/node/153129\">Find out more about The Budget</a></p>\r\n</div>\r\n</div>\r\n"
-          summary: ''
-          format: full_html
-  -
-    info: 'NIExec: Our documents'
-    langcode: en
-    uuid: 27d3b95c-b0e9-4887-b755-69cb0f360082
+    uuid: 4e9b2662-00ce-4467-90cb-ce9e13b9101d
     bundle: block_group
     revision_id: null
     rev_id_current: null
@@ -55,16 +29,42 @@ blocks:
             status: true
             info: ''
             view_mode: full
+  -
+    info: 'niexec: pfg'
+    langcode: en
+    uuid: ccc0d53e-810b-40c0-a368-2de586eb7771
+    bundle: basic
+    revision_id: null
+    rev_id_current: null
+    fields:
+      body:
         -
-          plugin_id: 'views_block:frontpage_our_documents-block_all_depts_latest_consultations'
-          settings:
-            id: 'views_block:frontpage_our_documents-block_all_depts_latest_consultations'
-            label: ''
-            label_display: visible
-            provider: views
-            views_label: ''
-            items_per_page: none
-            context_mapping: {  }
+          value: "<h3>Programme for Government</h3>\r\n<div class=\"card card--no-border card--no-padding\">\r\n\r\n<div class=\"card__image\">\r\n<drupal-media data-align=\"center\" data-entity-type=\"media\" data-entity-uuid=\"397bdb06-afa6-421e-8d23-911d10fd9f49\" data-view-mode=\"feature_card\"></drupal-media>\r\n</div>\r\n\r\n<div class=\"card__body\">\r\n<p>The Programme for Government (PfG) sets the strategic context for both the Budget and the Investment Strategy for Northern Ireland.</p>\r\n\r\n<p><a href=\"/node/152663\">Find out more about the PfG</a></p>\r\n</div>\r\n</div>\r\n"
+          summary: ''
+          format: full_html
+  -
+    info: 'niexec: budget'
+    langcode: en
+    uuid: bab5e511-c70f-40d0-9539-a9a1b00d909e
+    bundle: basic
+    revision_id: null
+    rev_id_current: null
+    fields:
+      body:
+        -
+          value: "<h3>Budget</h3>\r\n<div class=\"card card--no-border card--no-padding\">\r\n\r\n<div class=\"card__image\">\r\n<drupal-media data-align=\"center\" data-entity-type=\"media\" data-entity-uuid=\"52143c3d-ca63-4bc0-95ab-36bbefcfd6d2\" data-view-mode=\"feature_card\"></drupal-media>\r\n</div>\r\n\r\n<div class=\"card__body\">\r\n<p>The Budget provides the Executive with an opportunity to improve the lives of people in Northern Ireland by allocating resources to high priority areas.</p>\r\n\r\n<p><a href=\"/node/153129\">Find out more about The Budget</a></p>\r\n</div>\r\n</div>\r\n"
+          summary: ''
+          format: full_html
+  -
+    info: 'niexec: our documents'
+    langcode: en
+    uuid: 27d3b95c-b0e9-4887-b755-69cb0f360082
+    bundle: block_group
+    revision_id: null
+    rev_id_current: null
+    fields:
+      body: {  }
+      field_blocks:
         -
           plugin_id: 'views_block:frontpage_our_documents-block_all_depts_latest_publications'
           settings:
@@ -73,7 +73,17 @@ blocks:
             label_display: visible
             provider: views
             views_label: ''
-            items_per_page: none
+            items_per_page: '5'
+            context_mapping: {  }
+        -
+          plugin_id: 'views_block:frontpage_our_documents-block_all_depts_latest_consultations'
+          settings:
+            id: 'views_block:frontpage_our_documents-block_all_depts_latest_consultations'
+            label: ''
+            label_display: visible
+            provider: views
+            views_label: ''
+            items_per_page: '5'
             context_mapping: {  }
   -
     info: 'Our documents'
@@ -105,3 +115,12 @@ blocks:
             views_label: ''
             items_per_page: none
             context_mapping: {  }
+  -
+    info: 'Access to information'
+    langcode: en
+    uuid: 45f27a2e-f5cb-4e08-a300-e9a22d6cf30b
+    bundle: basic
+    revision_id: null
+    rev_id_current: null
+    fields:
+      body: {  }

--- a/config/sync/views.view.frontpage_our_documents.yml
+++ b/config/sync/views.view.frontpage_our_documents.yml
@@ -251,7 +251,7 @@ display:
     display_plugin: block
     position: 1
     display_options:
-      title: Consultations
+      title: 'Latest consultations'
       fields:
         title:
           id: title
@@ -583,7 +583,7 @@ display:
       display_description: ''
       use_more: true
       use_more_always: true
-      use_more_text: 'See all our consultations'
+      use_more_text: 'See all consultations'
       link_display: custom_url
       link_url: /consultations
       display_extenders: {  }
@@ -605,7 +605,7 @@ display:
     display_plugin: block
     position: 1
     display_options:
-      title: Publications
+      title: 'Latest publications'
       fields:
         title:
           id: title
@@ -937,7 +937,7 @@ display:
       display_description: ''
       use_more: true
       use_more_always: true
-      use_more_text: 'See all our publications'
+      use_more_text: 'See all publications'
       link_display: custom_url
       link_url: /publications
       display_extenders: {  }


### PR DESCRIPTION
Move Budget and PfG blocks out of "Our documents" block and into a new niexec featured topics block that sits below "Our responsibilities" (see https://github.com/dof-dss/nicsdru_dept_theme/pull/87)