### PR TITLE
Tidy up stray trailing spaces before the media wysiwyg filter

### DIFF
--- a/config/sync/migrate_plus.migration.node_actions.yml
+++ b/config/sync/migrate_plus.migration.node_actions.yml
@@ -1,4 +1,4 @@
-uuid: a0327537-1e39-4d32-8e42-9e987cd39c5e
+uuid: a7ac702c-a020-4bdd-be7e-01dfc600c8da
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_application.yml
+++ b/config/sync/migrate_plus.migration.node_application.yml
@@ -1,4 +1,4 @@
-uuid: 13fba058-1158-40bf-867c-eb93805080ea
+uuid: e60741e5-8c5e-4514-a28a-4a8155bb62c0
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_article.yml
+++ b/config/sync/migrate_plus.migration.node_article.yml
@@ -1,4 +1,4 @@
-uuid: 01a53871-3aa6-41d4-af1e-a34a51e60990
+uuid: ab3e3fcb-ec67-4d2f-ad76-1c92ab477097
 langcode: en
 status: true
 dependencies: {  }
@@ -42,12 +42,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_collection.yml
+++ b/config/sync/migrate_plus.migration.node_collection.yml
@@ -1,4 +1,4 @@
-uuid: 9eb0a833-d4e8-4096-9b4b-5480ef184823
+uuid: 22665fc4-527f-4c71-8592-198b857b2bee
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_consultation.yml
+++ b/config/sync/migrate_plus.migration.node_consultation.yml
@@ -1,4 +1,4 @@
-uuid: 5b30116d-28af-4c9a-90c0-2137e14cba64
+uuid: a1cc5b34-0009-468c-94ca-48cbd006a588
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_contact.yml
+++ b/config/sync/migrate_plus.migration.node_contact.yml
@@ -1,4 +1,4 @@
-uuid: 9167c70a-4664-44c4-810a-5b30841dee39
+uuid: 425ddfe4-e952-4d1c-adbf-dff56288da0c
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_easychart.yml
+++ b/config/sync/migrate_plus.migration.node_easychart.yml
@@ -1,4 +1,4 @@
-uuid: 15220523-aaef-4d36-b919-288bf7fd099c
+uuid: b7a1fa14-f6a2-407d-995b-a8a5edeecc75
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_gallery.yml
+++ b/config/sync/migrate_plus.migration.node_gallery.yml
@@ -1,4 +1,4 @@
-uuid: eac7762b-de80-48ec-9746-601568308c21
+uuid: f3fdfe4a-f9bc-4b79-be86-e269bef2a7f0
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_heritage_site.yml
+++ b/config/sync/migrate_plus.migration.node_heritage_site.yml
@@ -1,4 +1,4 @@
-uuid: f1168011-a883-453d-9e8d-da8a1bfe6090
+uuid: 92a17860-1c36-41e2-b4f3-30c226be046a
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_infogram.yml
+++ b/config/sync/migrate_plus.migration.node_infogram.yml
@@ -1,4 +1,4 @@
-uuid: 10564128-6a7e-4edd-bd33-7511800bea92
+uuid: 9dfddc84-c5f3-45f3-9207-41c000d9400f
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_landing_page.yml
+++ b/config/sync/migrate_plus.migration.node_landing_page.yml
@@ -1,4 +1,4 @@
-uuid: 0779896e-e2bd-459d-bdb9-55f2e76885e7
+uuid: a53ef568-a17b-4a22-bf9f-8c8740c7c7d4
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_news.yml
+++ b/config/sync/migrate_plus.migration.node_news.yml
@@ -1,4 +1,4 @@
-uuid: 363d1db7-5297-4d54-8c38-c7c2c504c95a
+uuid: e351c712-e918-44ad-998a-d39ab290bfaf
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_page.yml
+++ b/config/sync/migrate_plus.migration.node_page.yml
@@ -1,4 +1,4 @@
-uuid: 624a466c-d9f3-41ab-9efa-4f9e21635af6
+uuid: c68e7740-a8a3-4f66-88e8-a5193b6191cd
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_profile.yml
+++ b/config/sync/migrate_plus.migration.node_profile.yml
@@ -1,4 +1,4 @@
-uuid: 3b407c83-5ee6-4a9c-9206-69b2750e1f90
+uuid: ea8f52e3-aeda-4167-8ac9-e8a7f9a6bdb9
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_protected_area.yml
+++ b/config/sync/migrate_plus.migration.node_protected_area.yml
@@ -1,4 +1,4 @@
-uuid: ab4d0821-6550-49da-bfa6-13fb8bb316cc
+uuid: 5f0d0251-99bb-428a-902e-409de46d019b
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -1,4 +1,4 @@
-uuid: 8c2ade20-0cb0-42f0-b0c9-656aa52188f8
+uuid: a392301f-a182-4d86-9069-f9c8f1f2b627
 langcode: en
 status: true
 dependencies: {  }
@@ -58,12 +58,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_subtopic.yml
+++ b/config/sync/migrate_plus.migration.node_subtopic.yml
@@ -1,4 +1,4 @@
-uuid: 064baf10-1bd9-4f23-ac99-eb6365a01b60
+uuid: 9806dae6-097c-4fa5-ae67-360618ba1d26
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/config/sync/migrate_plus.migration.node_topic.yml
+++ b/config/sync/migrate_plus.migration.node_topic.yml
@@ -1,4 +1,4 @@
-uuid: a85f4ef4-93af-4a25-9261-5c7dc8ec773f
+uuid: c031b493-b6b4-4136-b107-7e9142bdcf32
 langcode: en
 status: true
 dependencies: {  }
@@ -56,12 +56,20 @@ process:
       plugin: get
       source: body
     -
-      plugin: media_wysiwyg_filter
-    -
       plugin: str_replace
       regex: true
       search: '/(<p>[<br>|\s]*&nbsp;<\/p>)/im'
       replace: ''
+    -
+      plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    -
+      plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    -
+      plugin: media_wysiwyg_filter
   body/0/format:
     -
       plugin: static_map

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_actions.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_actions.yml
@@ -45,11 +45,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_application.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_application.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_article.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_article.yml
@@ -32,11 +32,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_collection.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_collection.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_consultation.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_consultation.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_contact.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_contact.yml
@@ -45,11 +45,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_easychart.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_easychart.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_gallery.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_gallery.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_infogram.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_infogram.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_landing_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_landing_page.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_news.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_news.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_page.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_profile.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_profile.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_protected_area.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_protected_area.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -46,11 +46,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_subtopic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_subtopic.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_topic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_topic.yml
@@ -44,11 +44,17 @@ process:
   body:
     - plugin: get
       source: body
-    - plugin: media_wysiwyg_filter
     - plugin: str_replace
       regex: true
       search: /(<p>[<br>|\s]*&nbsp;<\/p>)/im
       replace: ''
+    - plugin: str_replace
+      search: '&nbsp;</p>'
+      replace: '</p>'
+    - plugin: str_replace
+      search: '&nbsp;'
+      replace: ' '
+    - plugin: media_wysiwyg_filter
   body/0/format:
     - plugin: static_map
       source: body/0/format


### PR DESCRIPTION
A bit rough around the edges for correcting unwanted line breaks and trailing spaces but it seems to work + doesn't truncate table content as we've seen in the past.