### PR TITLE
Fallback entity query if topic doesn't have subtopics defined in draggable views

### DIFF
--- a/web/modules/custom/dept_topics/src/ContentTopics.php
+++ b/web/modules/custom/dept_topics/src/ContentTopics.php
@@ -120,8 +120,22 @@ class ContentTopics {
       ->orderBy('weight', 'ASC');
 
     $ids = $query->execute()->fetchAllAssoc('entity_id');
-    $subtopic_nodes = \Drupal::entityTypeManager()
-      ->getStorage('node')->loadMultiple(array_keys($ids));
+
+    if (!empty($ids)) {
+      $subtopic_nodes = \Drupal::entityTypeManager()
+        ->getStorage('node')->loadMultiple(array_keys($ids));
+    }
+    else {
+      // No draggable views ordering, extract by parent topic id.
+      $subtopics_query = \Drupal::entityQuery('node')
+        ->condition('type', 'subtopic')
+        ->condition('status', 1)
+        ->condition('field_parent_topic', $node->id())
+        ->execute();
+
+      $subtopic_nodes = \Drupal::entityTypeManager()
+        ->getStorage('node')->loadMultiple(array_values($subtopics_query));
+    }
 
     foreach ($subtopic_nodes as $node) {
       $subtopics[$node->id()] = [


### PR DESCRIPTION
We had a similar edge case in subtopic listings where some articles weren't 100% accurate when syncing from D7. TLDR: we'd bring across what we reasonably can, then have site owners adjust/set this before launch after which the issue resolves itself and concentrates technical effort on higher value tasks.