### PR TITLE
Restore config for consultations search view

### DIFF
--- a/config/sync/views.view.consultations_search.yml
+++ b/config/sync/views.view.consultations_search.yml
@@ -326,9 +326,8 @@ display:
       tags:
         - 'config:field.storage.node.body'
         - 'config:search_api.index.consultations_index'
-        - 'search_api_list:consultations_index'
-  search:
-    id: search
+  consultations_search:
+    id: consultations_search
     display_title: Page
     display_plugin: page
     position: 1
@@ -343,7 +342,7 @@ display:
       display_extenders: {  }
       path: consultations
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -354,6 +353,7 @@ display:
         - url.site
         - 'user.node_grants:view'
       tags:
+        - 'config:facets.facet.consultation_publication_date'
+        - 'config:facets.facet.consultation_topic'
         - 'config:field.storage.node.body'
         - 'config:search_api.index.consultations_index'
-        - 'search_api_list:consultations_index'


### PR DESCRIPTION
Appears to fix config references in both related facets/facet blocks and custom code, restoring the missing sidebar blocks.