### PR TITLE
Disable link rewrites for canonical routes

### DIFF
--- a/config/sync/domain_source.settings.yml
+++ b/config/sync/domain_source.settings.yml
@@ -1,3 +1,19 @@
 _core:
   default_config_hash: mqVsLCNF_WfM-XDhZ0nuTWd7bjvrqR5a6K_-vd0bwjU
-exclude_routes: {  }
+exclude_routes:
+  canonical: canonical
+  delete_form: '0'
+  delete_multiple_form: '0'
+  edit_form: '0'
+  version_history: '0'
+  revision: '0'
+  create: '0'
+  book_outline_form: '0'
+  book_remove_form: '0'
+  scheduled_transitions: '0'
+  scheduled_transition_add: '0'
+  latest_version: '0'
+  devel_load: '0'
+  devel_render: '0'
+  devel_definition: '0'
+  token_devel: '0'


### PR DESCRIPTION
Change domain_source settings so that content sent to all affiliates is viewable on all affiliates and a redirect to the source domain does not occur.

(This is needed for "global" content shared by all domains - e.g. help content: crown copyright, privacy, terms and conditions, etc.)