### PR TITLE
DEPT-465 restore domain source/access field access and fix permissions

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - domain
     - eu_cookie_compliance
     - media
     - search_api_autocomplete
@@ -19,6 +20,7 @@ permissions:
   - 'display eu cookie compliance popup'
   - 'use search_api_autocomplete for search'
   - use_search_api_live_results
+  - 'view domain list'
   - 'view field_external_publication'
   - 'view files'
   - 'view media'

--- a/web/modules/custom/dept_core/dept_core.services.yml
+++ b/web/modules/custom/dept_core/dept_core.services.yml
@@ -15,6 +15,10 @@ services:
     arguments: ['@department.manager']
     tags:
       - { name: 'context_provider' }
+  department.route_subscriber:
+    class: Drupal\dept_core\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
 parameters:
   topic_route_patterns:
     - /publications/(topic)/(\d+)

--- a/web/modules/custom/dept_core/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/dept_core/src/Routing/RouteSubscriber.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\dept_core\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('domain.admin')) {
+      $route->setRequirements([
+        '_permission' => 'administer domains'
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
- Allows anon and auth users to see domain source/access field values; they're connected to a fairly obscure domain module permission.
- Overrides the permissions requirements for the admin/config/domain path so anon users can't see this list by guessing the path.