### PR TITLE
Update topics view and uninstall deprecated quickedit module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -137,7 +137,6 @@ module:
   path: 0
   path_alias: 0
   permissions_filter: 0
-  quickedit: 0
   redirect: 0
   redis: 0
   responsive_image: 0

--- a/config/sync/views.view.topics.yml
+++ b/config/sync/views.view.topics.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - core.entity_view_mode.node.topics_teaser
     - node.type.topic
     - system.menu.main
   module:
@@ -277,7 +276,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: topics_teaser
+          view_mode: teaser
       defaults:
         style: false
         row: false
@@ -530,7 +529,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: topics_teaser
+          view_mode: teaser
       defaults:
         style: false
         row: false


### PR DESCRIPTION
The "topics_teaser" view mode does not exist for topics (leading to some weirdness in twig templates).  Switch page and block views to using "teaser" view mode for topic output.

Also uninstall quickedit module.  Its deprecated and causes some render problems for topic teasers when it inserts quickedit contextual links