### PR TITLE
DEPT-468 ~ Add global topics to metadata for topic child content

### DIFF
--- a/config/sync/metatag.metatag_defaults.node__application.yml
+++ b/config/sync/metatag.metatag_defaults.node__application.yml
@@ -1,0 +1,8 @@
+uuid: 0e204af4-7acc-4e75-bd3f-c48fda85f2aa
+langcode: en
+status: true
+dependencies: {  }
+id: node__application
+label: 'Content: Application'
+tags:
+  article_tag: '[node:field_global_topics]'

--- a/config/sync/metatag.metatag_defaults.node__article.yml
+++ b/config/sync/metatag.metatag_defaults.node__article.yml
@@ -1,0 +1,8 @@
+uuid: a0223bb0-932c-466c-ab73-7c65ba65d3b5
+langcode: en
+status: true
+dependencies: {  }
+id: node__article
+label: 'Content: Article'
+tags:
+  article_tag: '[node:field_global_topics]'

--- a/config/sync/metatag.metatag_defaults.node__publication.yml
+++ b/config/sync/metatag.metatag_defaults.node__publication.yml
@@ -7,7 +7,7 @@ label: 'Content: Publication'
 tags:
   article_modified_time: '[node:created:custom:c]'
   article_published_time: '[node:created:custom:c]'
-  article_tag: '[node:field_site_topics],[node:field_site_subtopics]'
+  article_tag: '[node:field_global_topics],[node:field_site_topics],[node:field_site_subtopics]'
   canonical_url: '[current-page:url:absolute]'
   description: '[node:field_summary]'
   og_description: '[node:field_summary]'

--- a/config/sync/metatag.settings.yml
+++ b/config/sync/metatag.settings.yml
@@ -1,6 +1,21 @@
 entity_type_groups:
   node:
+    application:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    article:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
     consultation:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    contact:
       basic: basic
       advanced: advanced
       open_graph: open_graph
@@ -11,6 +26,7 @@ entity_type_groups:
       open_graph: open_graph
       twitter_cards: twitter_cards
 tag_trim_method: beforeValue
+use_maxlength: true
 tag_trim_maxlength:
   metatag_maxlength_abstract: null
   metatag_maxlength_description: null


### PR DESCRIPTION
Dropping in the global topics as part of the og article:tag output