### PR TITLE
Adjust topic picker widget to a permission for finer grained control

### DIFF
--- a/config/sync/user.role.admin.yml
+++ b/config/sync/user.role.admin.yml
@@ -507,6 +507,7 @@ permissions:
   - 'use text format filtered_html'
   - 'use text format filtered_html_with_no_images'
   - 'use text format filtered_html_with_tokens'
+  - 'use topic tree widget'
   - 'use workbench_media add form'
   - 'use workbench_moderation my drafts tab'
   - 'use workbench_moderation needs review tab'

--- a/config/sync/user.role.author.yml
+++ b/config/sync/user.role.author.yml
@@ -172,6 +172,7 @@ permissions:
   - 'use nics_editorial_workflow transition submit_for_review'
   - 'use text format filtered_html'
   - 'use text format filtered_html_with_no_images'
+  - 'use topic tree widget'
   - 'use workbench_moderation my drafts tab'
   - 'use workbench_moderation needs review tab'
   - 'view actions revisions'

--- a/config/sync/user.role.stats_author.yml
+++ b/config/sync/user.role.stats_author.yml
@@ -52,6 +52,7 @@ permissions:
   - 'use text format basic_html'
   - 'use text format filtered_html'
   - 'use text format filtered_html_with_no_images'
+  - 'use topic tree widget'
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view any unpublished secure_publication content'

--- a/config/sync/user.role.stats_supervisor.yml
+++ b/config/sync/user.role.stats_supervisor.yml
@@ -80,6 +80,7 @@ permissions:
   - 'use text format basic_html'
   - 'use text format filtered_html'
   - 'use text format filtered_html_with_no_images'
+  - 'use topic tree widget'
   - 'view all revisions'
   - 'view all scheduled transitions'
   - 'view any unpublished content'

--- a/config/sync/user.role.supervisor.yml
+++ b/config/sync/user.role.supervisor.yml
@@ -270,6 +270,7 @@ permissions:
   - 'use nics_editorial_workflow transition submit_for_review'
   - 'use text format filtered_html'
   - 'use text format filtered_html_with_no_images'
+  - 'use topic tree widget'
   - 'use workbench_moderation my drafts tab'
   - 'use workbench_moderation needs review tab'
   - 'view all media revisions'

--- a/config/sync/user.role.topic_layout_supervisor.yml
+++ b/config/sync/user.role.topic_layout_supervisor.yml
@@ -50,6 +50,7 @@ permissions:
   - 'update topic content on assigned domains'
   - 'use text format filtered_html_with_templates'
   - 'use text format layout_builder_html'
+  - 'use topic tree widget'
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view any unpublished landing_page content'

--- a/config/sync/user.role.topic_supervisor.yml
+++ b/config/sync/user.role.topic_supervisor.yml
@@ -115,6 +115,7 @@ permissions:
   - 'use text format filtered_html_with_no_images'
   - 'use text format filtered_html_with_templates'
   - 'use text format filtered_html_with_tokens'
+  - 'use topic tree widget'
   - 'use workbench_moderation my drafts tab'
   - 'use workbench_moderation needs review tab'
   - 'view all revisions'

--- a/web/modules/custom/dept_topics/dept_topics.permissions.yml
+++ b/web/modules/custom/dept_topics/dept_topics.permissions.yml
@@ -1,0 +1,2 @@
+use topic tree widget:
+  title: 'Use topic tree widget'

--- a/web/modules/custom/dept_topics/dept_topics.routing.yml
+++ b/web/modules/custom/dept_topics/dept_topics.routing.yml
@@ -4,7 +4,7 @@ dept_topics.topic_tree.json:
     _title: 'Topic tree field widget dataset'
     _controller: '\Drupal\dept_topics\Controller\TopicTreeDataController::allDepartmentTopics'
   requirements:
-    _permission: 'edit any subtopic content'
+    _permission: 'use topic tree widget'
 
 dept_topics.topic_tree.form:
   path: '/admin/topics/topic_tree/{department}/{field}/{selected}'
@@ -13,4 +13,4 @@ dept_topics.topic_tree.form:
     _form: 'Drupal\dept_topics\Form\TopicTreeForm'
     selected: ''
   requirements:
-    _permission: 'edit any subtopic content'
+    _permission: 'use topic tree widget'


### PR DESCRIPTION
Prior problem was that stats author (or similar future roles less than full author) roles could not use the topic picker without being given node permissions for topics/subtopics too which wasn't in the brief for those restricted roles.