### PR TITLE
Set TZ to localised TZ rather than UTC

### DIFF
--- a/config/sync/migrate_plus.migration.node_consultation.yml
+++ b/config/sync/migrate_plus.migration.node_consultation.yml
@@ -99,14 +99,14 @@ process:
         plugin: format_date
         source: value
         from_format: 'Y-m-d H:i:s'
-        from_timezone: UTC
+        from_timezone: Europe/London
         to_format: 'Y-m-d\TH:i:s'
         to_timezone: UTC
       end_value:
         plugin: format_date
         source: value2
         from_format: 'Y-m-d H:i:s'
-        from_timezone: UTC
+        from_timezone: Europe/London
         to_format: 'Y-m-d\TH:i:s'
         to_timezone: UTC
   field_global_topics:

--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -105,7 +105,7 @@ process:
           from_format: 'Y-m-d H:i:s'
           from_timezone: UTC
           to_format: 'Y-m-d\TH:i:s'
-          to_timezone: UTC
+          to_timezone: Europe/London
   field_global_topics:
     -
       plugin: sub_process

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_consultation.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_consultation.yml
@@ -81,14 +81,14 @@ process:
         plugin: format_date
         source: value
         from_format: 'Y-m-d H:i:s'
-        from_timezone: 'UTC'
+        from_timezone: 'Europe/London'
         to_format: 'Y-m-d\TH:i:s'
         to_timezone: 'UTC'
       end_value:
         plugin: format_date
         source: value2
         from_format: 'Y-m-d H:i:s'
-        from_timezone: 'UTC'
+        from_timezone: 'Europe/London'
         to_format: 'Y-m-d\TH:i:s'
         to_timezone: 'UTC'
   field_global_topics:

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -86,7 +86,7 @@ process:
           from_format: 'Y-m-d H:i:s'
           from_timezone: 'UTC'
           to_format: 'Y-m-d\TH:i:s'
-          to_timezone: 'UTC'
+          to_timezone: 'Europe/London'
   field_global_topics:
     - plugin: sub_process
       source: field_global_topics


### PR DESCRIPTION
This will set the time portion of the field value to, effectively, an hour behind but with BST offset this normalises the value. Without this, the values are pulled across and stored in UTC but Drupal will apply the localised TZ offset which often moves the rendered day value by 1 making the migration look broken.

These values will likely need to be reverted/reset once BST finishes, if content is still continuing to be migrated. Keeping the site TZ as UTC isn't an option though as scheduled transitions depends on the correct local time being kept.