### PR TITLE
DEPT-611

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -277,7 +277,8 @@
             },
             "drupal/domain": {
                 "Migration path for domain": "https://www.drupal.org/files/issues/2020-02-27/domain-migration-path-for-domain-2882837-13.patch",
-                "Available on Current Domain doesn't instantiate": "https://www.drupal.org/files/issues/2023-06-21/3367785-domain-php8-boolean.patch"
+                "Available on Current Domain doesn't instantiate": "https://www.drupal.org/files/issues/2023-06-21/3367785-domain-php8-boolean.patch",
+                "Cached routes are not deleted when the cache is cleared": "https://www.drupal.org/files/issues/2023-09-18/3266520-9.patch"
             },
             "drupal/domain_entity": {
                 "Domain Access field: machine name should match machine name declared on Domain Access module": "https://www.drupal.org/files/issues/2023-07-11/3129265-16.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b4487cb1b057559416f82d9a81d7508",
+    "content-hash": "b270ab25a3054a3791491419e24604b7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7007,7 +7007,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.30",
-                    "datestamp": "1697366291",
+                    "datestamp": "1700925904",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8680,6 +8680,10 @@
                     "name": "Johan Gant",
                     "homepage": "https://www.drupal.org/u/johangant",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "omahm",
+                    "homepage": "https://www.drupal.org/user/540058"
                 }
             ],
             "description": "Provides a report of what node entities link to the currently viewed node.",
@@ -18307,12 +18311,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -18357,6 +18361,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2023-02-22T23:07:41+00:00"
         },
         {

--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -60,6 +60,26 @@ function dept_core_preprocess_field(&$variables) {
  * Implements hook_preprocess_menu().
  */
 function dept_core_preprocess_menu(&$variables) {
+  // domain_source module does a variety of conversions for routed paths
+  // changing, for example, <front> from a relative path to the source/canonical
+  // domain's absolute URI. This causes some interesting disruption around what link
+  // is rendered for some things. It's extremely opaque as to precisely what
+  // causes this and how best to intercept/adjust, but nothing in domain_source.api.php
+  // triggers. DomainRouteProvider.php and DomainSourcePathProcess.php also don't seem
+  // to have a visible role in the rewriting of the route path.
+  if ($variables['menu_name'] === 'main' && !empty($variables['items'])) {
+    foreach ($variables['items'] as $id => &$item) {
+      $url = $item['url'];
+      /* @var \Drupal\Core\Url $item */
+      if ($url->getRouteName() === '<front>') {
+        /* @var \Drupal\dept_core\DepartmentManager $dept_manager */
+        $dept_manager = \Drupal::service('department.manager');
+        $current_dept = $dept_manager->getCurrentDepartment();
+        $item['url'] = Url::fromUri($current_dept->url());
+      }
+    }
+  }
+
   if ($variables['menu_name'] === 'footer' && !empty($variables['items'])) {
     // Add a menu link to the end of the menu with a link to the
     // accessibility statement defined in the group field value.

--- a/web/sites/default/services.yml
+++ b/web/sites/default/services.yml
@@ -83,7 +83,7 @@ parameters:
     # render array, hence varying every render array by these cache contexts.
     #
     # @default ['languages:language_interface', 'theme', 'user.permissions']
-    required_cache_contexts: ['languages:language_interface', 'theme', 'user.permissions']
+    required_cache_contexts: ['languages:language_interface', 'theme', 'user.permissions', 'url.site']
     # Renderer automatic placeholdering conditions:
     #
     # Drupal allows portions of the page to be automatically deferred when


### PR DESCRIPTION
Something of a cludge to rewrite the URL in the main menu. Very opaque as to where, precisely, domain/domain_source adjusts the routing based on the canonical domain set for content so I'd consider this a workaround than a preferred fix.

This ticket also adds an extra default cache context based on the domain hostname, so a variant of a render element will usually be produced for each domain rather than one domain's HTML being re-used across all domains.