### PR TITLE
DEPT-631

### DIFF
--- a/config/sync/user.role.stats_supervisor.yml
+++ b/config/sync/user.role.stats_supervisor.yml
@@ -41,6 +41,7 @@ permissions:
   - 'create publication content'
   - 'create publication content on assigned domains'
   - 'create publication node content on assigned domains'
+  - 'create secure publication'
   - 'create secure_file media content on assigned domains'
   - 'delete document media content on assigned domains'
   - 'delete image media content on assigned domains'

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -520,6 +520,50 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        field_publication_secure_files_target_id:
+          id: field_publication_secure_files_target_id
+          table: node__field_publication_secure_files
+          field: field_publication_secure_files_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          operator: empty
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -473,6 +473,47 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        uri:
+          id: uri
+          table: file_managed
+          field: uri
+          relationship: field_media_file_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: uri
+          plugin_id: string
+          operator: not_starts
+          value: 'private://'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/web/modules/custom/dept_publications/dept_publications.module
+++ b/web/modules/custom/dept_publications/dept_publications.module
@@ -24,30 +24,34 @@ function dept_publications_form_node_form_alter(&$form, FormStateInterface $form
   // attachment type.
   if ($node->bundle() === 'publication') {
     $form['publication_attachment_type'] = [
-      '#type' => 'radios',
-      '#title' => t('Attachment(s) type'),
-      '#options' => ['Public', 'Secure'],
-      '#default_value' => '0',
-      '#weight' => 0,
+      '#type' => 'hidden',
+      '#value' => '0',
     ];
 
-    $form['field_publication_files']['#states'] = [
-      'invisible' => [
-        ':input[name="publication_attachment_type"]' => ['value' => 1],
-      ],
-    ];
+    // If permission to create secure publication, make this field selectable.
+    if (\Drupal::currentUser()->hasPermission('create secure publication')) {
 
-    $form['field_external_publication']['#states'] = [
-      'invisible' => [
-        ':input[name="publication_attachment_type"]' => ['value' => 1],
-      ],
-    ];
+      \Drupal::messenger()->addMessage('This content will be created as a secure publication meaning it and related media assets cannot be seen by other users or site visitors until it is published');
+      $form['publication_attachment_type']['#value'] = 1;
 
-    $form['field_publication_secure_files']['#states'] = [
-      'invisible' => [
-        ':input[name="publication_attachment_type"]' => ['value' => 0],
-      ],
-    ];
+      $form['field_publication_files']['#states'] = [
+        'invisible' => [
+          ':input[name="publication_attachment_type"]' => ['value' => 1],
+        ],
+      ];
+
+      $form['field_external_publication']['#states'] = [
+        'invisible' => [
+          ':input[name="publication_attachment_type"]' => ['value' => 1],
+        ],
+      ];
+
+      $form['field_publication_secure_files']['#states'] = [
+        'invisible' => [
+          ':input[name="publication_attachment_type"]' => ['value' => 0],
+        ],
+      ];
+    }
 
     if (!empty($node->get('field_publication_secure_files')->getValue())) {
       $form['publication_attachment_type']['#default_value'] = 1;
@@ -125,5 +129,15 @@ function dept_publications_entity_operation_alter(array &$operations, EntityInte
         return $operations;
       }
     }
+  }
+}
+
+/**
+ * Implements hook_file_download().
+ */
+function dept_publications_file_download($uri) {
+  // Return -1 which is then later converted to AccessDeniedHttpException response.
+  if (\Drupal::service('secure_publications_file_access')->canAccessSecureFileAttachment($uri) === FALSE) {
+    return -1;
   }
 }

--- a/web/modules/custom/dept_publications/dept_publications.module
+++ b/web/modules/custom/dept_publications/dept_publications.module
@@ -155,9 +155,9 @@ function dept_publications_views_pre_execute(ViewExecutable $view) {
  * Implements hook_views_query_alter().
  */
 function dept_publications_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  if ($view->id() === 'content' && $view->current_display == 'page_1') {
-    $current_user = \Drupal::currentUser();
+  $current_user = \Drupal::currentUser();
 
+  if ($view->id() === 'content' && $view->current_display == 'page_1') {
     foreach ($query->where[1]['conditions'] as $index => $condition) {
       if ($condition['field'] === 'node__field_publication_secure_files.field_publication_secure_files_target_id') {
         // Unset this condition if stats supervisor/related permissions.
@@ -168,6 +168,23 @@ function dept_publications_views_query_alter(ViewExecutable $view, QueryPluginBa
           if ($current_user->hasPermission('bypass node access')) {
             \Drupal::messenger()
               ->addWarning('Secure publications are included in this content list due to appropriate permissions for the current user. This message only shows for top-level admins.');
+          }
+        }
+      }
+    }
+  }
+
+  if ($view->id() === 'media_library') {
+    foreach ($query->where[1]['conditions'] as $index => $condition) {
+      if ($condition['field'] === 'file_managed_media__field_media_file.uri') {
+        // Unset this condition if stats supervisor/related permissions.
+        if ($current_user->hasPermission('view any unpublished secure publication')) {
+          unset($query->where[1]['conditions'][$index]);
+
+          // Set a notice message for top-level admins.
+          if ($current_user->hasPermission('administer media')) {
+            \Drupal::messenger()
+              ->addWarning('Files for secure publications are included in this content list due to appropriate permissions for the current user. This message only shows for top-level admins.');
           }
         }
       }

--- a/web/modules/custom/dept_publications/dept_publications.module
+++ b/web/modules/custom/dept_publications/dept_publications.module
@@ -10,6 +10,8 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
@@ -139,5 +141,36 @@ function dept_publications_file_download($uri) {
   // Return -1 which is then later converted to AccessDeniedHttpException response.
   if (\Drupal::service('secure_publications_file_access')->canAccessSecureFileAttachment($uri) === FALSE) {
     return -1;
+  }
+}
+
+/**
+ * Implements hook_views_pre_execute().
+ */
+function dept_publications_views_pre_execute(ViewExecutable $view) {
+
+}
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function dept_publications_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ($view->id() === 'content' && $view->current_display == 'page_1') {
+    $current_user = \Drupal::currentUser();
+
+    foreach ($query->where[1]['conditions'] as $index => $condition) {
+      if ($condition['field'] === 'node__field_publication_secure_files.field_publication_secure_files_target_id') {
+        // Unset this condition if stats supervisor/related permissions.
+        if ($current_user->hasPermission('view any unpublished secure publication')) {
+          unset($query->where[1]['conditions'][$index]);
+
+          // Set a notice message for top-level admins.
+          if ($current_user->hasPermission('bypass node access')) {
+            \Drupal::messenger()
+              ->addWarning('Secure publications are included in this content list due to appropriate permissions for the current user. This message only shows for top-level admins.');
+          }
+        }
+      }
+    }
   }
 }

--- a/web/modules/custom/dept_publications/dept_publications.module
+++ b/web/modules/custom/dept_publications/dept_publications.module
@@ -158,6 +158,7 @@ function dept_publications_views_query_alter(ViewExecutable $view, QueryPluginBa
   $current_user = \Drupal::currentUser();
 
   if ($view->id() === 'content' && $view->current_display == 'page_1') {
+    // @phpstan-ignore-next-line
     foreach ($query->where[1]['conditions'] as $index => $condition) {
       if ($condition['field'] === 'node__field_publication_secure_files.field_publication_secure_files_target_id') {
         // Unset this condition if stats supervisor/related permissions.
@@ -175,6 +176,7 @@ function dept_publications_views_query_alter(ViewExecutable $view, QueryPluginBa
   }
 
   if ($view->id() === 'media_library') {
+    // @phpstan-ignore-next-line
     foreach ($query->where[1]['conditions'] as $index => $condition) {
       if ($condition['field'] === 'file_managed_media__field_media_file.uri') {
         // Unset this condition if stats supervisor/related permissions.

--- a/web/modules/custom/dept_publications/dept_publications.permissions.yml
+++ b/web/modules/custom/dept_publications/dept_publications.permissions.yml
@@ -1,3 +1,5 @@
+create secure publication:
+  title: 'Create secure variation of publication content'
 view own unpublished secure publication:
   title: 'View own unpublished secure publication content'
 view any unpublished secure publication:

--- a/web/modules/custom/dept_publications/dept_publications.services.yml
+++ b/web/modules/custom/dept_publications/dept_publications.services.yml
@@ -1,4 +1,7 @@
 services:
+  secure_publications_file_access:
+    class: Drupal\dept_publications\SecurePublicationsFileAccess
+    arguments: ['file_uri', '@current_user', '@database', '@entity_type.manager']
   secure_publications.route_subscriber:
     class: Drupal\dept_publications\Routing\SecurePublicationsRouteSubscriber
     tags:

--- a/web/modules/custom/dept_publications/src/SecurePublicationsFileAccess.php
+++ b/web/modules/custom/dept_publications/src/SecurePublicationsFileAccess.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\dept_publications;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+
+class SecurePublicationsFileAccess {
+
+  /**
+   * @var string
+   */
+  protected $fileUri;
+
+  /**
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $user;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @param string $file_uri
+   *   The URI of a file.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user service object.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection object.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager service object.
+   */
+  public function __construct(string $file_uri, AccountInterface $user, Connection $connection, EntityTypeManagerInterface $entity_type_manager) {
+    $this->fileUri = $file_uri;
+    $this->user = $user;
+    $this->connection = $connection;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * @param string $file_uri
+   *   File uri, eg: private://directory/file.pdf.
+   *
+   * @return bool
+   *   TRUE if can access, FALSE if not.
+   */
+  public function canAccessSecureFileAttachment(string $file_uri) {
+    $sql = "SELECT DISTINCT
+      fm.uri,
+      fm.fid,
+      fm.filename,
+      mfd.mid,
+      mfd.name,
+      nfd.nid,
+      nfd.type,
+      nfd.title
+      FROM file_managed fm
+      JOIN file_usage fu ON fu.fid = fm.fid
+      JOIN media_field_data mfd ON mfd.mid = fu.id
+      JOIN node__field_publication_secure_files nfpsf ON nfpsf.field_publication_secure_files_target_id = mfd.mid
+      JOIN node_field_data nfd ON nfd.nid = nfpsf.entity_id
+      WHERE nfd.type = 'publication'
+      AND fm.uri = :file_uri";
+
+    $results = $this->connection->query($sql, [':file_uri' => $file_uri])->fetchAssoc();
+
+    if (empty($results)) {
+      return FALSE;
+    }
+
+    // See if this is a published publication node.
+    $nid = $results['nid'];
+
+    /* @var \Drupal\node\NodeInterface $node */
+    $node = $this->entityTypeManager->getStorage('node')->load($nid);
+
+    if ($node->isPublished() && $node->bundle() === 'publication') {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+}


### PR DESCRIPTION
- Exclude publication nodes with secure files attachments from:
  - Main content listing
  - Media assets from media library 
- Default publication node form to secure publication fields if the user has the permission to do so