### PR TITLE
Migration taxo issues

### DIFF
--- a/config/sync/migrate_plus.migration.d7_taxonomy_term_chart_type.yml
+++ b/config/sync/migrate_plus.migration.d7_taxonomy_term_chart_type.yml
@@ -17,11 +17,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    -
-      plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: chart_type
   name: name
   description/value:
     -

--- a/config/sync/migrate_plus.migration.d7_taxonomy_term_global_topics.yml
+++ b/config/sync/migrate_plus.migration.d7_taxonomy_term_global_topics.yml
@@ -17,11 +17,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    -
-      plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: global_topics
   name: name
   description/value:
     -

--- a/config/sync/migrate_plus.migration.d7_taxonomy_term_indicators.yml
+++ b/config/sync/migrate_plus.migration.d7_taxonomy_term_indicators.yml
@@ -17,11 +17,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    -
-      plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: indicators
   name: name
   description/value:
     -

--- a/config/sync/migrate_plus.migration.d7_taxonomy_term_outcomes.yml
+++ b/config/sync/migrate_plus.migration.d7_taxonomy_term_outcomes.yml
@@ -17,11 +17,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    -
-      plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: outcomes
   name: name
   description/value:
     -

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -79,7 +79,7 @@ then
   done
 
   echo "Migrating D7 taxonomy data"
-  $DRUSH migrate:import --group=migrate_drupal_7_taxo --force
+  $DRUSH migrate:import --group=migrate_drupal_7_taxo
 
   echo "Migrating D7 user and roles"
   $DRUSH migrate:import users --force

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -100,6 +100,10 @@ then
     $DRUSH migrate:import d7_file_media_document --force --limit=10000
   done
 
+  # Turn off content_lock modules as they interfere with node and redirect entity creation here.
+  $DRUSH pmu content_lock,content_lock_timeout
+  # NB: module will be re-enabled by config import at end of this script.
+
   for type in topic subtopic actions application article collection consultation contact easychart gallery heritage_site infogram landing_page link page profile protected_area ual
   do
     echo "Migrate D7 ${type} nodes"

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_chart_type.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_chart_type.yml
@@ -16,10 +16,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    - plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: 'chart_type'
   name: name
   description/value:
     -

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_global_topics.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_global_topics.yml
@@ -16,10 +16,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    - plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: 'global_topics'
   name: name
   description/value:
     -

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_indicators.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_indicators.yml
@@ -16,10 +16,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    - plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: 'indicators'
   name: name
   description/value:
     -

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_outcomes.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install/migrate_plus.migration.d7_taxonomy_term_outcomes.yml
@@ -16,10 +16,7 @@ source:
   batch_size: 1000
 process:
   tid: tid
-  vid:
-    - plugin: migration_lookup
-      migration: upgrade_d7_taxonomy_vocabulary
-      source: vid
+  vid: 'outcomes'
   name: name
   description/value:
     -


### PR DESCRIPTION
- Replace needless migrate lookups with fixed values
- turn off content lock modules at start of nightly migration (re-enabled at the end by config import)