### PR TITLE
Convert static query into dynamic query to better manage placeholders and expressions

### DIFF
--- a/web/modules/custom/dept_sitemap/dept_sitemap.module
+++ b/web/modules/custom/dept_sitemap/dept_sitemap.module
@@ -103,7 +103,13 @@ function dept_sitemap_cron() {
     $replace = '.lndo.site';
   }
 
-  \Drupal::database()->query("UPDATE {simple_sitemap}
-    SET sitemap_string = REPLACE(sitemap_string, '.*.uk-1.platformsh.site', $replace)
-    WHERE delta = :delta", [':delta' => 0])->execute();
+  // Use dynamic query for update - see advice on d.o for complex expression queries.
+  // https://www.drupal.org/docs/8/api/database-api/dynamic-queries/introduction-to-dynamic-queries.
+  $query = \Drupal::database()->update('simple_sitemap')
+    ->expression('sitemap_string', "REPLACE(sitemap_string, :find, :replace)", [
+      ':find' => '.*.uk-1.platformsh.site',
+      ':replace' => $replace,
+    ])
+    ->condition('delta', 0)
+    ->execute();
 }


### PR DESCRIPTION
Existing cron query failed due to problems escaping the REPLACE() expression string and values for it. Adjusted to a dynamic query as per guidelines on https://www.drupal.org/docs/8/api/database-api/dynamic-queries/introduction-to-dynamic-queries and this now works again.