### PR TITLE
More detailed pass/replacements for dept sitemap namespace URLs across indexes and pages

### DIFF
--- a/web/modules/custom/dept_sitemap/dept_sitemap.module
+++ b/web/modules/custom/dept_sitemap/dept_sitemap.module
@@ -58,6 +58,10 @@ function dept_sitemap_cron() {
       $replace = "https://{$dept_prefix}.lndo.site";
     }
 
+    if (empty($replace)) {
+      continue;
+    }
+
     // Use dynamic query for update - see advice on d.o for complex expression queries.
     // https://www.drupal.org/docs/8/api/database-api/dynamic-queries/introduction-to-dynamic-queries.
     $query = \Drupal::database()->update('simple_sitemap')

--- a/web/modules/custom/dept_sitemap/dept_sitemap.module
+++ b/web/modules/custom/dept_sitemap/dept_sitemap.module
@@ -27,22 +27,60 @@ function dept_sitemap_cron() {
   // https://finance-ni.*.uk-1.platformsh.site
   // to this
   // https://finance-ni.main-bvxea6i-dnvkwx4xjhiza.uk-1.platformsh.site
+  // We need to load the dept from the simple_sitemap column value,
+  // otherwise we have no context of the dept from running via drush
+  // or relying on existing URL strings in the XML which is a bit flaky.
+  $depts = \Drupal::database()->query("SELECT DISTINCT `type` FROM {simple_sitemap} WHERE delta=0")->fetchCol(0);
 
-  if (empty(getenv('PLATFORM_ENVIRONMENT'))) {
-    // Don't update if not on PSH cluster.
-    return;
+  foreach ($depts as $dept_id) {
+    $dept = \Drupal::service('department.manager')->getDepartment($dept_id);
+
+    if ($dept instanceof Department === FALSE) {
+      continue;
+    }
+
+    $dept_url_bits = parse_url($dept->url());
+    $dept_prefix = explode('.', $dept_url_bits['host'])[0];
+
+    if (empty($dept_prefix)) {
+      continue;
+    }
+
+    if (empty(getenv('PLATFORM_ENVIRONMENT'))) {
+      $replace = sprintf("https://%s.%s-%s.uk-1.platformsh.site",
+        $dept_prefix,
+        getenv('PLATFORM_ENVIRONMENT') ?? '',
+        getenv('PLATFORM_PROJECT') ?? '');
+    }
+
+    // Local dev override.
+    if (!empty(getenv('LANDO'))) {
+      $replace = "https://{$dept_prefix}.lndo.site";
+    }
+
+    // Use dynamic query for update - see advice on d.o for complex expression queries.
+    // https://www.drupal.org/docs/8/api/database-api/dynamic-queries/introduction-to-dynamic-queries.
+    $query = \Drupal::database()->update('simple_sitemap')
+      ->expression('sitemap_string', "REGEXP_REPLACE(sitemap_string, :find_expression, :replace)", [
+        ':find_expression' => 'http(?:s?):\/\/.*?([^\.\/]+?\.[^\.]+?)(?:\/|$)',
+        ':replace' => $replace . '/',
+      ])
+      ->condition('type', $dept_id)
+      ->condition('sitemap_string', "%{$replace}%", 'NOT LIKE')
+      ->execute();
+
+    // REGEX_REPLACE will break the <sitemapindex namespace URL, so patch it up here.
+    $query = \Drupal::database()->update('simple_sitemap')
+      ->expression('sitemap_string', "REPLACE(sitemap_string, :incorrect_xmlns, :correct_xmlns)", [
+        ':incorrect_xmlns' => "<sitemapindex xmlns=\"{$replace}/schemas/sitemap/0.9\">",
+        ':correct_xmlns' => '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+      ])->execute();
+
+    // Ditto for the <urlset namespace links.
+    $query = \Drupal::database()->update('simple_sitemap')
+      ->expression('sitemap_string', "REPLACE(sitemap_string, :incorrect_urlset, :correct_urlset)", [
+        ':incorrect_urlset' => "<urlset xmlns=\"{$replace}/schemas/sitemap/0.9\" xmlns:xhtml=\"$replace/1999/xhtml\" xmlns:image=\"{$replace}/schemas/sitemap-image/1.1\">",
+        ':correct_urlset' => '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
+      ])->execute();
   }
-
-  $replace = sprintf("https://.%s-%s.uk-1.platformsh.site",
-    getenv('PLATFORM_ENVIRONMENT') ?? '',
-    getenv('PLATFORM_PROJECT') ?? '');
-
-  // Use dynamic query for update - see advice on d.o for complex expression queries.
-  // https://www.drupal.org/docs/8/api/database-api/dynamic-queries/introduction-to-dynamic-queries.
-  $query = \Drupal::database()->update('simple_sitemap')
-    ->expression('sitemap_string', "REGEXP_REPLACE(sitemap_string, :find_expression, :replace)", [
-      ':find_expression' => 'http(?:s?):\/\/.*?([^\.\/]+?\.[^\.]+?)(?:\/|$)',
-      ':replace' => $replace . '/',
-    ])
-    ->execute();
 }


### PR DESCRIPTION
- Past, single update query didn't capture the dept prefix. Fixes this.
- REGEX_REPLACE unfortunately also affects the namespaces for the XML docs so we need to selectively patch that up, or the documents don't render