### PR TITLE
Disable link rewrite/redirect for node canonical paths

### DIFF
--- a/config/sync/field.field.node.application.field_domain_source.yml
+++ b/config/sync/field.field.node.application.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.application.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.article.field_domain_source.yml
+++ b/config/sync/field.field.node.article.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.article.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.book.field_domain_source.yml
+++ b/config/sync/field.field.node.book.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.book.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.contact.field_domain_source.yml
+++ b/config/sync/field.field.node.contact.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.contact.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.featured_content_list.field_domain_source.yml
+++ b/config/sync/field.field.node.featured_content_list.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.featured_content_list.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.gallery.field_domain_source.yml
+++ b/config/sync/field.field.node.gallery.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.gallery.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.global_page.field_domain_source.yml
+++ b/config/sync/field.field.node.global_page.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.global_page.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.heritage_site.field_domain_source.yml
+++ b/config/sync/field.field.node.heritage_site.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.heritage_site.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.link.field_domain_source.yml
+++ b/config/sync/field.field.node.link.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.link.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.page.field_domain_source.yml
+++ b/config/sync/field.field.node.page.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.page.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.profile.field_domain_source.yml
+++ b/config/sync/field.field.node.profile.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.profile.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.protected_area.field_domain_source.yml
+++ b/config/sync/field.field.node.protected_area.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.protected_area.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.publication.field_domain_source.yml
+++ b/config/sync/field.field.node.publication.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.publication.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.subtopic.field_domain_source.yml
+++ b/config/sync/field.field.node.subtopic.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.subtopic.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.topic.field_domain_source.yml
+++ b/config/sync/field.field.node.topic.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.topic.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.ual.field_domain_source.yml
+++ b/config/sync/field.field.node.ual.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.ual.field_domain_source
 field_name: field_domain_source
 entity_type: node

--- a/config/sync/field.field.node.webform.field_domain_source.yml
+++ b/config/sync/field.field.node.webform.field_domain_source.yml
@@ -9,7 +9,8 @@ dependencies:
     - domain_entity
 third_party_settings:
   domain_entity:
-    exclude_routes: {  }
+    exclude_routes:
+      canonical: canonical
 id: node.webform.field_domain_source
 field_name: field_domain_source
 entity_type: node


### PR DESCRIPTION
Turn this off and it means a node shared to a domain can be seen on that domain, instead of redirecting to the hostname defined from the domain source field value.