### PR TITLE
Omit config import step as it appears to alter how active migrate config operates despite having the same definition

### DIFF
--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -84,14 +84,14 @@ then
     $DRUSH migrate:reset $m
   done
 
-  echo "Make sure active config matches that from migrate modules"
-  $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_flags/config/install -y
-  $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install -y
-
-  for type in users files nodes
-  do
-    $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_$type/config/install -y
-  done
+#  echo "Make sure active config matches that from migrate modules"
+#  $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_flags/config/install -y
+#  $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_taxo/config/install -y
+#
+#  for type in users files nodes
+#  do
+#    $DRUSH cim --partial --source=/app/web/modules/custom/dept_migrate/modules/dept_migrate_$type/config/install -y
+#  done
 
   echo "Migrating D7 taxonomy data"
   $DRUSH migrate:import --group=migrate_drupal_7_taxo
@@ -99,21 +99,21 @@ then
   echo "Migrating D7 user and roles"
   $DRUSH migrate:import users --force
 
-  echo "Migrating D7 files and media entities"
-  $DRUSH migrate:import d7_file_private --force
-  $DRUSH migrate:import d7_file --force
-
-  for type in image video secure_file
-  do
-    echo "Migrating D7 ${type} to corresponding media entities"
-    $DRUSH migrate:import d7_file_media_$type --force
-  done
-
-  echo "Migrating D7 file documents to corresponding media entities"
-  for i in {1..10}
-  do
-    $DRUSH migrate:import d7_file_media_document --force --limit=10000
-  done
+#  echo "Migrating D7 files and media entities"
+#  $DRUSH migrate:import d7_file_private --force
+#  $DRUSH migrate:import d7_file --force
+#
+#  for type in image video secure_file
+#  do
+#    echo "Migrating D7 ${type} to corresponding media entities"
+#    $DRUSH migrate:import d7_file_media_$type --force
+#  done
+#
+#  echo "Migrating D7 file documents to corresponding media entities"
+#  for i in {1..10}
+#  do
+#    $DRUSH migrate:import d7_file_media_document --force --limit=10000
+#  done
 
   # Turn off content_lock modules as they interfere with node and redirect entity creation here.
   $DRUSH pmu content_lock,content_lock_timeout

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -99,21 +99,21 @@ then
   echo "Migrating D7 user and roles"
   $DRUSH migrate:import users --force
 
-#  echo "Migrating D7 files and media entities"
-#  $DRUSH migrate:import d7_file_private --force
-#  $DRUSH migrate:import d7_file --force
-#
-#  for type in image video secure_file
-#  do
-#    echo "Migrating D7 ${type} to corresponding media entities"
-#    $DRUSH migrate:import d7_file_media_$type --force
-#  done
-#
-#  echo "Migrating D7 file documents to corresponding media entities"
-#  for i in {1..10}
-#  do
-#    $DRUSH migrate:import d7_file_media_document --force --limit=10000
-#  done
+  echo "Migrating D7 files and media entities"
+  $DRUSH migrate:import d7_file_private --force
+  $DRUSH migrate:import d7_file --force
+
+  for type in image video secure_file
+  do
+    echo "Migrating D7 ${type} to corresponding media entities"
+    $DRUSH migrate:import d7_file_media_$type --force
+  done
+
+  echo "Migrating D7 file documents to corresponding media entities"
+  for i in {1..10}
+  do
+    $DRUSH migrate:import d7_file_media_document --force --limit=10000
+  done
 
   # Turn off content_lock modules as they interfere with node and redirect entity creation here.
   $DRUSH pmu content_lock,content_lock_timeout


### PR DESCRIPTION
Very weird outcome but is repeatable locally. Once merged, source_row_status needs to be set to 1 for all node types in the map tables in order to ensure they're up to date again.