### PR TITLE
DEPT-759 manage content AJAX matcher dialog

### DIFF
--- a/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
+++ b/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
@@ -286,7 +286,6 @@ final class ManageTopicContentForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    return;
     $parents = $form_state->getTriggeringElement()['#parents'];
 
     // Append call.
@@ -299,7 +298,7 @@ final class ManageTopicContentForm extends FormBase {
       }
 
       // We only want valid url paths and not the typed text.
-      if (!str_starts_with($add_path, 'http')) {
+      if (!UrlHelper::isExternal($add_path) && UrlHelper::isValid($add_path, TRUE)) {
         $form_state->setErrorByName('add_path', 'Path must be a valid URL');
         return;
       }

--- a/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
+++ b/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\dept_topics\Form;
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\CloseModalDialogCommand;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -285,6 +286,7 @@ final class ManageTopicContentForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
+    return;
     $parents = $form_state->getTriggeringElement()['#parents'];
 
     // Append call.
@@ -403,11 +405,16 @@ final class ManageTopicContentForm extends FormBase {
    */
   protected function extractNodeIdFromUrl(string $url):int {
     // Strip the host and match the alias to a node id.
-    $host = $this->getRequest()->getSchemeAndHttpHost();
-    $alias = substr($url, strlen($host));
-    $path = $this->aliasManager->getPathByAlias($alias);
-
-    $nid = (int) substr($path, 6);
+    if (UrlHelper::isExternal($url)) {
+      $host = $this->getRequest()->getSchemeAndHttpHost();
+      $alias = substr($url, strlen($host));
+      $path = $this->aliasManager->getPathByAlias($alias);
+      $nid = (int) substr($path, 6);
+    }
+    else {
+      // Canonical URL. Trim to extract the node id parameter.
+      $nid = (int) substr($url, 6);
+    }
 
     return $nid;
   }

--- a/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
+++ b/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
@@ -298,7 +298,7 @@ final class ManageTopicContentForm extends FormBase {
       }
 
       // We only want valid url paths and not the typed text.
-      if (!UrlHelper::isExternal($add_path) && UrlHelper::isValid($add_path, TRUE)) {
+      if (!str_starts_with($add_path, '/node/')) {
         $form_state->setErrorByName('add_path', 'Path must be a valid URL');
         return;
       }


### PR DESCRIPTION
What comes back to the form appears to be a canonical path instead of an absolute path. Adjusted validation to validate if there's not a canonical node path matched.