### PR TITLE
Remove facets patch (surplus to requirement, causes runtime error)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -294,8 +294,7 @@
                 "Make module compatible with PHP 8.2 #3405907": "https://www.drupal.org/files/issues/2023-12-04/3405907-1.patch"
             },
             "drupal/facets": {
-                "Incompatibilities between facets_pretty_paths and facets 2.0": "https://www.drupal.org/files/issues/2022-03-09/facet_summary_reset-3268360-3.patch",
-                "Fix to deprecated function $transliterateDisplayValue": "https://www.drupal.org/files/issues/2024-02-21/facets-php82-3406085-18.patch"
+                "Incompatibilities between facets_pretty_paths and facets 2.0": "https://www.drupal.org/files/issues/2022-03-09/facet_summary_reset-3268360-3.patch"
             },
             "drupal/facets_pretty_paths": {
                 "Composite patch for issues 2952005 and 3254600": "https://gist.githubusercontent.com/johangant/00ba5b48ea73dc23c68fa31389e59b31/raw/867a56ab06bce67f9cbfae65d3dd3b974e09b92a/fpp-result-count-query-handler.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56710b729b380227cefd6a18e61eabd2",
+    "content-hash": "657b25b3b931a935cb91f241efa1c469",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Patch applies cleanly, but introduces duplicate class properties which triggers a fatal runtime error. We've already got these class properties defined as per https://www.drupal.org/files/issues/2024-02-25/3336646-48.patch and the facets pages load with no log warnings or db log entries.