### PR TITLE
DEPT-780 refactor and adjust cache busting when book outline changes or content is removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -280,7 +280,8 @@
                 "Length of menu_tree.url and menu_tree.route_param_key are too short (255 characters)": "https://www.drupal.org/files/issues/2024-03-06/3106205-55-10-2.patch",
                 "Avoid error when $options is NULL in buildUrl()": "https://www.drupal.org/files/issues/2022-10-03/2871217-68_0.patch",
                 "Increase claro xs font size": "patches/claro-font-size.patch",
-                "TypeError when adding book page": "https://www.drupal.org/files/issues/2023-10-02/book_typeerror-3391035-1.patch"
+                "TypeError when adding book page": "https://www.drupal.org/files/issues/2023-10-02/book_typeerror-3391035-1.patch",
+                "Force expiration of node cache tag when book outline changes": "https://gist.githubusercontent.com/johangant/8b97bf93525475ee89d8be246a418777/raw/145c727d1df7403ce38819437bc46989e1a85a2b/expire-book-node-cache-key-on-change.patch"
             },
             "drupal/devel": {
                 "Brings back the Available Methods & Properties tabs for Kint dumps — Issue #221": "https://raw.githubusercontent.com/politsin/snipets/master/patch/kint.patch"

--- a/composer.json
+++ b/composer.json
@@ -279,7 +279,8 @@
                 "Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2022-12-14/2918537-92.patch",
                 "Length of menu_tree.url and menu_tree.route_param_key are too short (255 characters)": "https://www.drupal.org/files/issues/2024-03-06/3106205-55-10-2.patch",
                 "Avoid error when $options is NULL in buildUrl()": "https://www.drupal.org/files/issues/2022-10-03/2871217-68_0.patch",
-                "Increase claro xs font size": "patches/claro-font-size.patch"
+                "Increase claro xs font size": "patches/claro-font-size.patch",
+                "TypeError when adding book page": "https://www.drupal.org/files/issues/2023-10-02/book_typeerror-3391035-1.patch"
             },
             "drupal/devel": {
                 "Brings back the Available Methods & Properties tabs for Kint dumps — Issue #221": "https://raw.githubusercontent.com/politsin/snipets/master/patch/kint.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f1cec7a6941c98112911f7457a9d6ee",
+    "content-hash": "cde5bc550060f9019c7a46c75626530e",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "657b25b3b931a935cb91f241efa1c469",
+    "content-hash": "3f1cec7a6941c98112911f7457a9d6ee",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -45,6 +45,7 @@ module:
   datetime: 0
   datetime_range: 0
   dblog: 0
+  dept_book: 0
   dept_content_processors: 0
   dept_core: 0
   dept_homepage: 0

--- a/web/modules/custom/dept_book/dept_book.info.yml
+++ b/web/modules/custom/dept_book/dept_book.info.yml
@@ -1,0 +1,9 @@
+name: 'Departmental sites: book'
+type: module
+description: 'Provides overrides and changes for handling book content.'
+package: 'NICS: Departmental'
+core_version_requirement: ^8 || ^9 || ^10 || ^10
+dependencies:
+  - drupal:book
+  - flag
+  - origins_toc

--- a/web/modules/custom/dept_book/dept_book.module
+++ b/web/modules/custom/dept_book/dept_book.module
@@ -68,9 +68,6 @@ function dept_book_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   // Interject in the book outline form. Purge cache items
   // from affected book ids and associated node id cache entries.
   if (preg_match('/book_(outline|remove)/', $form_id) && !str_contains($form_id, 'ajax')) {
-    // Unusual to apply to pre and post-submit but seems to require both
-    // See BookOutlineForm.php and BookRemoveForm.php.
-    $form['#submit'] = array_merge(['dept_book_structure_change_cache_clear'], $form['#submit']);
     $form['#submit'][] = 'dept_book_structure_change_cache_clear';
   }
 }
@@ -89,4 +86,16 @@ function dept_book_structure_change_cache_clear(&$form, FormStateInterface $form
   }
 
   Cache::invalidateTags($cache_tags);
+}
+
+/**
+ * Implements hook_preprocess_book_navigation().
+ */
+function dept_book_preprocess_book_navigation(&$variables) {
+  // Set some top level tags we can use to expire whenever
+  // a book outline is changed or a node removed from a book.
+  $variables['#cache']['tags'] = [
+    'bid:' . $variables['book_link']['bid'],
+    'node:' . $variables['book_link']['nid'],
+  ];
 }

--- a/web/modules/custom/dept_book/dept_book.module
+++ b/web/modules/custom/dept_book/dept_book.module
@@ -5,6 +5,8 @@
  * Book admendments for Departmental sites.
  */
 
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\flag\FlagInterface;
 use Drupal\node\NodeInterface;
 
@@ -59,4 +61,32 @@ function dept_book_node_update(EntityInterface $entity) {
   }
 }
 
+/**
+ * Implements hook_form_alter().
+ */
+function dept_book_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Interject in the book outline form. Purge cache items
+  // from affected book ids and associated node id cache entries.
+  if (preg_match('/book_(outline|remove)/', $form_id) && !str_contains($form_id, 'ajax')) {
+    // Unusual to apply to pre and post-submit but seems to require both
+    // See BookOutlineForm.php and BookRemoveForm.php.
+    $form['#submit'] = array_merge(['dept_book_structure_change_cache_clear'], $form['#submit']);
+    $form['#submit'][] = 'dept_book_structure_change_cache_clear';
+  }
+}
 
+/**
+ * Form submit callback used to purge cache items
+ * for books and the node being affected.
+ */
+function dept_book_structure_change_cache_clear(&$form, FormStateInterface $form_state) {
+  $book = $form_state->get('book') ?? [];
+  $cache_tags = [];
+
+  if (!empty($book['book'])) {
+    $cache_tags[] = 'bid:' . $book['book']['bid'];
+    $cache_tags[] = 'node:' . $book['book']['nid'];
+  }
+
+  Cache::invalidateTags($cache_tags);
+}

--- a/web/modules/custom/dept_book/dept_book.module
+++ b/web/modules/custom/dept_book/dept_book.module
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @file
+ * Book admendments for Departmental sites.
+ */
+
+use Drupal\flag\FlagInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function dept_book_entity_type_alter(array &$entity_types) {
+  // Remove BookOutlineConstraint to permit outline changes to
+  // nodes/books regardless of publish status.
+  /* @var \Drupal\Core\Entity\ContentEntityTypeInterface $node_entity_type */
+  $node_entity_type = &$entity_types['node'];
+  $constraints = $node_entity_type->getConstraints();
+
+  if (array_key_exists('BookOutline', $constraints)) {
+    unset($constraints['BookOutline']);
+    $node_entity_type->setConstraints($constraints);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function dept_book_node_update(EntityInterface $entity) {
+  if ($entity instanceof NodeInterface === FALSE) {
+    return;
+  }
+
+  $book = $entity->book ?? NULL;
+
+  if (empty($book)) {
+    return;
+  }
+
+  if ($book['bid'] === $book['nid']) {
+    /* @var \Drupal\flag\FlagServiceInterface $flag_service */
+    $flag_service = \Drupal::service('flag');
+    /* @var \Drupal\flag\FlagCountManagerInterface $flag_count_service */
+    $flag_count_service = \Drupal::service('flag.count');
+
+    // Has the node already had the ToC flag set? If so, nothing to do.
+    $flags = $flag_count_service->getEntityFlagCounts($entity);
+    if (array_key_exists('disable_toc', $flags) && $flags['disable_toc'] == 1) {
+      return;
+    }
+
+    $toc_flag = $flag_service->getFlagById('disable_toc');
+
+    // Flag the content to disable the toc.
+    if ($toc_flag instanceof FlagInterface) {
+      $flag_service->flag($toc_flag, $entity);
+    }
+  }
+}
+
+

--- a/web/modules/custom/dept_book/dept_book.module
+++ b/web/modules/custom/dept_book/dept_book.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\flag\FlagInterface;
 use Drupal\node\NodeInterface;

--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -402,14 +402,6 @@ function dept_core_clientside_validation_should_validate($element, FormStateInte
     return TRUE;
   }
 }
-
-/**
- * Implements hook_preprocess_book_navigation().
- */
-function dept_core_preprocess_book_navigation(&$variables) {
-  $variables['#cache']['max-age'] = 0;
-}
-
 /**
  * Implements hook_ENTITY_TYPE_update().
  */

--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -402,37 +402,3 @@ function dept_core_clientside_validation_should_validate($element, FormStateInte
     return TRUE;
   }
 }
-/**
- * Implements hook_ENTITY_TYPE_update().
- */
-function dept_core_node_update(EntityInterface $entity) {
-  if ($entity instanceof NodeInterface === FALSE) {
-    return;
-  }
-
-  $book = $entity->book ?? NULL;
-
-  if (empty($book)) {
-    return;
-  }
-
-  if ($book['bid'] === $book['nid']) {
-    /* @var \Drupal\flag\FlagServiceInterface $flag_service */
-    $flag_service = \Drupal::service('flag');
-    /* @var \Drupal\flag\FlagCountManagerInterface $flag_count_service */
-    $flag_count_service = Drupal::service('flag.count');
-
-    // Has the node already had the ToC flag set? If so, nothing to do.
-    $flags = $flag_count_service->getEntityFlagCounts($entity);
-    if (array_key_exists('disable_toc', $flags) && $flags['disable_toc'] == 1) {
-      return;
-    }
-
-    $toc_flag = $flag_service->getFlagById('disable_toc');
-
-    // Flag the content to disable the toc.
-    if ($toc_flag instanceof FlagInterface) {
-      $flag_service->flag($toc_flag, $entity);
-    }
-  }
-}


### PR DESCRIPTION
Book module expires 'bid:123' style keys, but not the related node tag meaning changes aren't reflected right away when adjusting a book outline.

Had to shoehorn in a small patch to core to get this to work as post-submit handlers didn't seem to work. Doubled up with suitable, related cache tags added to the book nav block and expirations on the book outline removal form, too.