### PR TITLE
Tweak memory limit over baseline config for drush commands and node forms

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -1,11 +1,5 @@
 <?php
 
-// Default Drupal 8 settings.
-//
-// These are already explained with detailed comments in Drupal's
-// default.settings.php file.
-//
-// See https://api.drupal.org/api/drupal/sites!default!default.settings.php/8
 $databases = [];
 $config_directories = [];
 $settings['update_free_access'] = FALSE;
@@ -44,6 +38,13 @@ $settings['config_readonly'] = (bool) getenv('CONFIG_READONLY');
 // Permit changes via command line.
 if (PHP_SAPI === 'cli') {
   $settings['config_readonly'] = FALSE;
+  // Increase memory for occasional drush tooling that needs it, eg: migration.
+  ini_set('memory_limit', '384M');
+}
+
+// Increase baseline memory on very specific paths to overcome dev env limits.
+if (preg_match('#^\/node\/(add|edit\/\d+)#', $_SERVER['REQUEST_URI'])) {
+  ini_set('memory_limit', '192M');
 }
 
 // Configuration that is allowed to be changed in readonly environments.


### PR DESCRIPTION
**Drush**

- Config import runs out of memory with drush; seems quite greedy but only used once or twice during deployments.
- Migrate status quite greedy too but used very infrequently.

**Node forms**

- DAERA topics tree is larger than others and with other page widgets it needs around 160M vs 130M for Finance. Giving it a comfortable bit of headroom here.
- Path limited to ensure this doesn't enable PSH burst mode for memory for every request. Sadly can't use route names here as the container isn't available early on in request handling phase.