### PR TITLE
DEPT-835 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -282,7 +282,8 @@
                 "Avoid error when $options is NULL in buildUrl()": "https://www.drupal.org/files/issues/2022-10-03/2871217-68_0.patch",
                 "Increase claro xs font size": "patches/claro-font-size.patch",
                 "TypeError when adding book page": "https://www.drupal.org/files/issues/2023-10-02/book_typeerror-3391035-1.patch",
-                "Force expiration of node cache tag when book outline changes": "https://gist.githubusercontent.com/johangant/8b97bf93525475ee89d8be246a418777/raw/145c727d1df7403ce38819437bc46989e1a85a2b/expire-book-node-cache-key-on-change.patch"
+                "Force expiration of node cache tag when book outline changes": "https://gist.githubusercontent.com/johangant/8b97bf93525475ee89d8be246a418777/raw/145c727d1df7403ce38819437bc46989e1a85a2b/expire-book-node-cache-key-on-change.patch",
+                "Stubs should only be created if the referenced source row actually exists": "https://www.drupal.org/files/issues/2024-01-04/core-create_stub_only_when_matching_source_row_exists-3156730-57--10.2.x.patch"
             },
             "drupal/devel": {
                 "Brings back the Available Methods & Properties tabs for Kint dumps — Issue #221": "https://raw.githubusercontent.com/politsin/snipets/master/patch/kint.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "261742ea067c0e1c12c63508a9528d2d",
+    "content-hash": "201538599e6d32ae019759f1e8864abb",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/sync/migrate_plus.migration.node_news.yml
+++ b/config/sync/migrate_plus.migration.node_news.yml
@@ -108,16 +108,6 @@ process:
   field_notes_to_editors: field_notes_to_editors
   field_notes_to_editors/0/format: basic_html
   field_teaser: field_teaser
-  field_photo:
-    -
-      plugin: sub_process
-      source: field_photo
-      process:
-        target_id:
-          -
-            plugin: d7_file_lookup
-            source: fid
-            entity_type: media
   field_video:
     -
       plugin: sub_process

--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -135,30 +135,6 @@ process:
           from_format: 'Y-m-d H:i:s'
           to_format: Y-m-d
           source: value
-  field_publication_files:
-    plugin: sub_process
-    source: field_attachment
-    process:
-      target_id:
-        -
-          plugin: d7_file_lookup
-          source: fid
-          entity_type: media
-        -
-          plugin: default_value
-          default_value: 97431
-  field_publication_secure_files:
-    plugin: sub_process
-    source: field_secure_attachment
-    process:
-      target_id:
-        -
-          plugin: d7_file_lookup
-          source: fid
-          entity_type: media
-        -
-          plugin: default_value
-          default_value: 97431
   field_external_publication:
     plugin: sub_process
     source: field_external_publication

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_news.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_news.yml
@@ -88,14 +88,14 @@ process:
   field_notes_to_editors: field_notes_to_editors
   field_notes_to_editors/0/format: basic_html
   field_teaser: field_teaser
-  field_photo:
-    - plugin: sub_process
-      source: field_photo
-      process:
-        target_id:
-          - plugin: d7_file_lookup
-            source: fid
-            entity_type: media
+#  field_photo:
+#    - plugin: sub_process
+#      source: field_photo
+#      process:
+#        target_id:
+#          - plugin: d7_file_lookup
+#            source: fid
+#            entity_type: media
   field_video:
     - plugin: sub_process
       source: field_video

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -112,26 +112,26 @@ process:
           from_format: 'Y-m-d H:i:s'
           to_format: 'Y-m-d'
           source: value
-  field_publication_files:
-    plugin: sub_process
-    source: field_attachment
-    process:
-      target_id:
-        - plugin: d7_file_lookup
-          source: fid
-          entity_type: media
-        - plugin: default_value
-          default_value: 97431
-  field_publication_secure_files:
-    plugin: sub_process
-    source: field_secure_attachment
-    process:
-      target_id:
-        - plugin: d7_file_lookup
-          source: fid
-          entity_type: media
-        - plugin: default_value
-          default_value: 97431
+#  field_publication_files:
+#    plugin: sub_process
+#    source: field_attachment
+#    process:
+#      target_id:
+#        - plugin: d7_file_lookup
+#          source: fid
+#          entity_type: media
+#        - plugin: default_value
+#          default_value: 97431
+#  field_publication_secure_files:
+#    plugin: sub_process
+#    source: field_secure_attachment
+#    process:
+#      target_id:
+#        - plugin: d7_file_lookup
+#          source: fid
+#          entity_type: media
+#        - plugin: default_value
+#          default_value: 97431
   field_external_publication:
     plugin: sub_process
     source: field_external_publication


### PR DESCRIPTION
Two steps needed here:

- First deploy: removes the mapping for D7toD10 media lookup so the nodes can be saved and registered in D10.
- Second deploy: reinstate the mapping and re-run the publication and news migration to let it update from source data as needed. As it will have a D10 id in the migrate map, this then works.

Added an upstream patch for D11 which improves migration stubbing. Probably not actively involved here but it looks useful anyway.