### PR TITLE
Attach custom JS to toolbar render element to fix hostname discrepancies

### DIFF
--- a/web/modules/custom/dept_homepage/dept_homepage.info.yml
+++ b/web/modules/custom/dept_homepage/dept_homepage.info.yml
@@ -1,5 +1,5 @@
 name: 'Department Homepage'
 type: module
 description: 'Functionality relating to the site homepage'
-core_version_requirement: ^8 || ^9 || ^10 || ^10
+core_version_requirement: ^8 || ^9 || ^10
 package: 'NICS: Departmental'

--- a/web/modules/custom/dept_homepage/dept_homepage.libraries.yml
+++ b/web/modules/custom/dept_homepage/dept_homepage.libraries.yml
@@ -1,0 +1,5 @@
+normalise_base_url:
+  js:
+    js/normalise_base_url.js: {}
+  dependencies:
+    - core/jquery

--- a/web/modules/custom/dept_homepage/dept_homepage.module
+++ b/web/modules/custom/dept_homepage/dept_homepage.module
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Contains dept_homepage.module.
+ */
+
+/**
+ * Implements hook_preprocess_toolbar().
+ */
+function dept_homepage_preprocess_toolbar(&$variables) {
+  // Attach JS library to toolbar render element.
+  $variables['#attached']['library'][] = 'dept_homepage/normalise_base_url';
+}

--- a/web/modules/custom/dept_homepage/js/normalise_base_url.js
+++ b/web/modules/custom/dept_homepage/js/normalise_base_url.js
@@ -11,12 +11,13 @@
     attach: function (context, settings) {
       $('a[href^="http"]:not(#toolbar-item-sites-tray a)').each(function (index, linkElement) {
         let href = $(linkElement).attr('href');
+        const currentDeptUrl = $(location).attr('origin');
         const currentDeptHostname = $(location).attr('host');
 
         // Absolute link, check if it matches our dept hostname.
         if (href.indexOf(currentDeptHostname) < 0) {
           // Not found/different, so adjust the hostname to the current dept.
-          href = href.replace(href, currentDeptHostname);
+          href = href.replace(href, currentDeptUrl);
           $(linkElement).attr('href', href);
         }
       });

--- a/web/modules/custom/dept_homepage/js/normalise_base_url.js
+++ b/web/modules/custom/dept_homepage/js/normalise_base_url.js
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * Javascript behaviors for adjusting the toolbar's base url
+ * where domain route caching might have failed.
+ */
+(function ($) {
+
+  "use strict";
+
+  Drupal.behaviors.normaliseBaseUrl = {
+    attach: function (context, settings) {
+      $('a[href^="http"]:not(#toolbar-item-sites-tray a)').each(function (index, linkElement) {
+        let href = $(linkElement).attr('href');
+        const currentDeptHostname = $(location).attr('host');
+
+        // Absolute link, check if it matches our dept hostname.
+        if (href.indexOf(currentDeptHostname) < 0) {
+          // Not found/different, so adjust the hostname to the current dept.
+          href = href.replace(href, currentDeptHostname);
+          $(linkElement).attr('href', href);
+        }
+      });
+    },
+  }
+
+}(jQuery, Drupal));


### PR DESCRIPTION
Clientside workaround that checks the paths of any absolute links in the toolbar, except the 'Sites' menu. If any absolute links are found then they're replaced with values using the current site's hostname.

![image](https://github.com/user-attachments/assets/034313cf-3909-45a7-b707-5b8ca4132b6f)

NB: this should be managed by domain/domain_source modules but due to some very opaque issues with the way cache items are generated, keyed and re-used in those modules the default domain sometimes is used for the <front> route path. Not a lot we can do server side to preprocess this owing to the way route paths are cached and altered by domain_source module. Even altering the toolbar render element doesn't seem to work around the issue. This could, potentially, pop up in other cases where something might need an absolute URL to the current department's front page but in those instances I would suggest using a relative path when generating the URL, as and when required.