### PR TITLE
Remove file remove button for non-admin users to encourage media entity deletion

### DIFF
--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -410,3 +410,12 @@ function dept_core_page_attachments(array &$attachments) {
     $attachments['#attached']['library'][] = 'nicsdru_dept_theme/admin-content';
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK() for file_managed_file.
+ */
+function dept_core_preprocess_file_managed_file(&$variables) {
+  if (\Drupal::currentUser()->hasPermission('delete any file') === FALSE) {
+    unset($variables['element']['remove_button']);
+  }
+}

--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -415,6 +415,10 @@ function dept_core_page_attachments(array &$attachments) {
  * Implements hook_preprocess_HOOK() for file_managed_file.
  */
 function dept_core_preprocess_file_managed_file(&$variables) {
+  if (empty($variables['element']['remove_button'])) {
+    return;
+  }
+
   if (\Drupal::currentUser()->hasPermission('delete any file') === FALSE) {
     unset($variables['element']['remove_button']);
   }


### PR DESCRIPTION
Admins can still remove the file but regular users will be encourage to delete the containing media entity to avoid orphaned content being created.