### PR TITLE
Quick fix for help viewing documents link

### DIFF
--- a/web/themes/custom/nicsdru_dept_theme/templates/field/field--field-attachment.html.twig
+++ b/web/themes/custom/nicsdru_dept_theme/templates/field/field--field-attachment.html.twig
@@ -62,7 +62,11 @@
   </ul>
 
   <p class="help-viewing-documents">
-    <a href="{{ path('entity.node.canonical', {'node': '207066'}) }}">{{ 'Help viewing documents'|t }}</a>
+    {% if department.id == 'nigov' %}
+      <a href="{{ path('entity.node.canonical', {'node': '207066'}) }}">{{ 'Help viewing documents'|t }}</a>
+    {% else %}
+      <a href="/articles/help-viewing-documents-{{ department.id }}">{{ 'Help viewing documents'|t }}</a>
+    {% endif %}
   </p>
 
 {% endif %}

--- a/web/themes/custom/nicsdru_nidirect_theme/templates/field/field--field-attachment.html.twig
+++ b/web/themes/custom/nicsdru_nidirect_theme/templates/field/field--field-attachment.html.twig
@@ -59,7 +59,11 @@
         {% endfor %}
       </ul>
       <p class="help-viewing-documents">
-        <a href="{{ path('entity.node.canonical', {'node': '5643'}) }}">{{ 'Help viewing documents'|t }}</a>
+        {% if department.id == 'nigov' %}
+          <a href="{{ path('entity.node.canonical', {'node': '207066'}) }}">{{ 'Help viewing documents'|t }}</a>
+        {% else %}
+          <a href="/articles/help-viewing-documents-{{ department.id }}">{{ 'Help viewing documents'|t }}</a>
+        {% endif %}
       </p>
     </div>
   </div>

--- a/web/themes/custom/nicsdru_nidirect_theme/templates/field/field--field-secure-attachment.html.twig
+++ b/web/themes/custom/nicsdru_nidirect_theme/templates/field/field--field-secure-attachment.html.twig
@@ -59,7 +59,11 @@
         {% endfor %}
       </ul>
       <p class="help-viewing-documents">
-        <a href="{{ path('entity.node.canonical', {'node': '5643'}) }}">{{ 'Help viewing documents'|t }}</a>
+        {% if department.id == 'nigov' %}
+          <a href="{{ path('entity.node.canonical', {'node': '207066'}) }}">{{ 'Help viewing documents'|t }}</a>
+        {% else %}
+          <a href="/articles/help-viewing-documents-{{ department.id }}">{{ 'Help viewing documents'|t }}</a>
+        {% endif %}
       </p>
     </div>
   </div>


### PR DESCRIPTION
Help viewing documents link should point at a dept specific page rather than the nigov source page.