### PR TITLE
Add www. prefix to all live dept hostnames

### DIFF
--- a/config/sync/domain.record.communities.yml
+++ b/config/sync/domain.record.communities.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: communities
 domain_id: 12430989
-hostname: communities-ni.gov.uk
+hostname: www.communities-ni.gov.uk
 name: 'Department for Communities'
 scheme: variable
 weight: -9

--- a/config/sync/domain.record.daera.yml
+++ b/config/sync/domain.record.daera.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: daera
 domain_id: 15704709
-hostname: daera-ni.gov.uk
+hostname: www.daera-ni.gov.uk
 name: 'Department of Agriculture, Environment and Rural Affairs'
 scheme: variable
 weight: -10

--- a/config/sync/domain.record.economy.yml
+++ b/config/sync/domain.record.economy.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: economy
 domain_id: 13100900
-hostname: economy-ni.gov.uk
+hostname: www.economy-ni.gov.uk
 name: 'Department for the Economy'
 scheme: variable
 weight: -8

--- a/config/sync/domain.record.education.yml
+++ b/config/sync/domain.record.education.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: education
 domain_id: 4684632
-hostname: education-ni.gov.uk
+hostname: www.education-ni.gov.uk
 name: 'Department for Education'
 scheme: variable
 weight: -7

--- a/config/sync/domain.record.executiveoffice.yml
+++ b/config/sync/domain.record.executiveoffice.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: executiveoffice
 domain_id: 1440456
-hostname: executiveoffice-ni.gov.uk
+hostname: www.executiveoffice-ni.gov.uk
 name: 'The Executive Office'
 scheme: variable
 weight: -2

--- a/config/sync/domain.record.health.yml
+++ b/config/sync/domain.record.health.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: health
 domain_id: 3257447
-hostname: health-ni.gov.uk
+hostname: www.health-ni.gov.uk
 name: 'Department for Health'
 scheme: variable
 weight: -5

--- a/config/sync/domain.record.infrastructure.yml
+++ b/config/sync/domain.record.infrastructure.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: infrastructure
 domain_id: 9344227
-hostname: infrastructure-ni.gov.uk
+hostname: www.infrastructure-ni.gov.uk
 name: 'Department for Infrastructure'
 scheme: variable
 weight: -4

--- a/config/sync/domain.record.justice.yml
+++ b/config/sync/domain.record.justice.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: justice
 domain_id: 13450482
-hostname: justice-ni.gov.uk
+hostname: www.justice-ni.gov.uk
 name: 'Department of Justice'
 scheme: variable
 weight: -3

--- a/config/sync/domain.record.nigov.yml
+++ b/config/sync/domain.record.nigov.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: nigov
 domain_id: 11933791
-hostname: northernireland.gov.uk
+hostname: www.northernireland.gov.uk
 name: 'The Northern Ireland Executive'
 scheme: variable
 weight: -11


### PR DESCRIPTION
When launching a site, you'll want to remove the entry in config/production to avoid replacing the live hostname with a PSH hostname used for production/pre-launch