### PR TITLE
Robots.txt - disallow facet urls

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -59,9 +59,7 @@ Disallow: /index.php/user/password
 Disallow: /index.php/user/register
 Disallow: /index.php/user/login
 Disallow: /index.php/user/logout
-
 # NICS custom
-
 # Files
 Disallow: /*.pdf
 Disallow: /*.doc
@@ -76,3 +74,27 @@ Disallow: /*.ods
 Disallow: /*.odp
 Disallow: /*.dot
 Disallow: /*.zip
+# Paths (no clean URLs)
+Disallow: /consultations?*
+Disallow: /news?*
+Disallow: /press-releases?*
+Disallow: /publications?*
+Allow: /consultations?page=*
+Allow: /news?page=*
+Allow: /press-releases?page=*
+Allow: /publications?page=*
+# Paths (clean URLs)
+Disallow: /consultations/type/
+Disallow: /consultations/topic/
+Disallow: /consultations/date/
+Disallow: /news/type/
+Disallow: /news/topic/
+Disallow: /news/date/
+Disallow: /news/feed/
+Disallow: /press-releases/type/
+Disallow: /press-releases/topic/
+Disallow: /press-releases/date/
+Disallow: /publications/type/
+Disallow: /publications/topic/
+Disallow: /publications/date/
+# TODO add sitemaps


### PR DESCRIPTION
Tested with https://technicalseo.com/tools/robots-txt/

Allowed: https://www.finance-ni.gov.uk/news?page=1
Disallowed: https://www.finance-ni.gov.uk/news?f%5B0%5D=topic%3A412572&f%5B1%5D=topic%3A412572