### PR TITLE
Dept 922

### DIFF
--- a/config/sync/migrate_plus.migration.node_application.yml
+++ b/config/sync/migrate_plus.migration.node_application.yml
@@ -150,8 +150,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_article.yml
+++ b/config/sync/migrate_plus.migration.node_article.yml
@@ -141,8 +141,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_collection.yml
+++ b/config/sync/migrate_plus.migration.node_collection.yml
@@ -103,8 +103,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_consultation.yml
+++ b/config/sync/migrate_plus.migration.node_consultation.yml
@@ -191,8 +191,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_contact.yml
+++ b/config/sync/migrate_plus.migration.node_contact.yml
@@ -146,8 +146,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_gallery.yml
+++ b/config/sync/migrate_plus.migration.node_gallery.yml
@@ -152,8 +152,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_heritage_site.yml
+++ b/config/sync/migrate_plus.migration.node_heritage_site.yml
@@ -212,8 +212,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_link.yml
+++ b/config/sync/migrate_plus.migration.node_link.yml
@@ -97,8 +97,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_news.yml
+++ b/config/sync/migrate_plus.migration.node_news.yml
@@ -178,8 +178,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_page.yml
+++ b/config/sync/migrate_plus.migration.node_page.yml
@@ -103,8 +103,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_profile.yml
+++ b/config/sync/migrate_plus.migration.node_profile.yml
@@ -122,8 +122,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_protected_area.yml
+++ b/config/sync/migrate_plus.migration.node_protected_area.yml
@@ -132,8 +132,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -197,8 +197,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_subtopic.yml
+++ b/config/sync/migrate_plus.migration.node_subtopic.yml
@@ -129,8 +129,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_topic.yml
+++ b/config/sync/migrate_plus.migration.node_topic.yml
@@ -121,8 +121,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.node_ual.yml
+++ b/config/sync/migrate_plus.migration.node_ual.yml
@@ -112,8 +112,11 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     -
       plugin: skip_on_condition
       condition:

--- a/config/sync/migrate_plus.migration.users.yml
+++ b/config/sync/migrate_plus.migration.users.yml
@@ -24,7 +24,14 @@ process:
       value:
         - 0
         - 1
-  name: name
+  name:
+    -
+      plugin: skip_on_value
+      method: row
+      source: name
+      value:
+        - connollyl
+        - nw_test_author
   pass: pass
   mail: mail
   created: created
@@ -67,37 +74,11 @@ process:
         default_value: null
   field_domain_access:
     -
-      plugin: skip_on_value
-      method: row
-      source: uid
-      value:
-        - 1
-    -
       plugin: sub_process
       source: domain_access_user
       process:
-        target_id:
-          -
-            plugin: skip_on_empty
-            method: row
-            source: target_id
-          -
-            plugin: static_map
-            bypass: true
-            source: target_id
-            map:
-              newnigov: nigov
-              execoffice: executiveoffice
-              dfp: finance
-  field_domain_source:
-    -
-      plugin: static_map
-      source: domain_source_user
-      bypass: true
-      map:
-        newnigov: nigov
-        execoffice: executiveoffice
-        dfp: finance
+        target_id: target_id
+  field_domain_source: domain_source_user
   list_of_depts_to_ignore:
     -
       plugin: callback
@@ -113,8 +94,13 @@ process:
       delimiter: ','
   ignore_live_depts:
     -
-      plugin: flatten
+      plugin: extract
       source: domain_source_user
+      index:
+        - target_id
+    -
+      plugin: default_value
+      default_value: nigov
     -
       plugin: skip_on_condition
       condition:

--- a/migrate-scripts/migrate.sh
+++ b/migrate-scripts/migrate.sh
@@ -96,8 +96,8 @@ then
   echo "Migrating D7 taxonomy data"
   $DRUSH migrate:import --group=migrate_drupal_7_taxo
 
-  echo "Migrating D7 user and roles -- TEMP SKIPPED"
-  # $DRUSH migrate:import users --force
+  echo "Migrating D7 user and roles"
+  $DRUSH migrate:import users --force
 
   echo "Migrating D7 files and media entities"
   $DRUSH migrate:import d7_file_private --force

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_application.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_application.yml
@@ -121,8 +121,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_article.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_article.yml
@@ -113,8 +113,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_collection.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_collection.yml
@@ -83,8 +83,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_consultation.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_consultation.yml
@@ -159,8 +159,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_contact.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_contact.yml
@@ -122,8 +122,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_gallery.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_gallery.yml
@@ -122,8 +122,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_heritage_site.yml
@@ -180,8 +180,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_link.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_link.yml
@@ -78,8 +78,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_news.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_news.yml
@@ -144,8 +144,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_page.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_page.yml
@@ -83,8 +83,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_profile.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_profile.yml
@@ -98,8 +98,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_protected_area.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_protected_area.yml
@@ -107,8 +107,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -163,8 +163,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_subtopic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_subtopic.yml
@@ -104,8 +104,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_topic.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_topic.yml
@@ -97,8 +97,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_ual.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_ual.yml
@@ -92,8 +92,11 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_node
+      index:
+        - 0
+        - target_id
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_users/config/install/migrate_plus.migration.users.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_users/config/install/migrate_plus.migration.users.yml
@@ -19,7 +19,13 @@ process:
       value:
         - 0
         - 1
-  name: name
+  name:
+    - plugin: skip_on_value
+      method: row
+      source: name
+      value:
+        - connollyl
+        - nw_test_author
   pass: pass
   mail: mail
   created: created
@@ -60,33 +66,11 @@ process:
         17: null
         default_value: null
   field_domain_access:
-    - plugin: skip_on_value
-      method: row
-      source: uid
-      value:
-      - 1
     - plugin: sub_process
       source: domain_access_user
       process:
-        target_id:
-          - plugin: skip_on_empty
-            method: row
-            source: target_id
-          - plugin: static_map
-            bypass: true
-            source: target_id
-            map:
-              'newnigov': 'nigov'
-              'execoffice': 'executiveoffice'
-              'dfp': 'finance'
-  field_domain_source:
-    - plugin: static_map
-      source: domain_source_user
-      bypass: true
-      map:
-        'newnigov': 'nigov'
-        'execoffice': 'executiveoffice'
-        'dfp': 'finance'
+        target_id: target_id
+  field_domain_source: domain_source_user
   list_of_depts_to_ignore:
     - plugin: callback
       callable: getenv
@@ -98,8 +82,12 @@ process:
     - plugin: explode
       delimiter: ','
   ignore_live_depts:
-    - plugin: flatten
+    - plugin: extract
       source: domain_source_user
+      index:
+        - target_id
+    - plugin: default_value
+      default_value: nigov
     - plugin: skip_on_condition
       condition:
         plugin: in_array

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_users/config/install/migrate_plus.migration_group.migrate_users.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_users/config/install/migrate_plus.migration_group.migrate_users.yml
@@ -6,6 +6,3 @@ label: 'Departmental sites -- Users'
 description: 'Migrate users'
 source_type: 'Drupal 7'
 module: null
-shared_configuration:
-  source:
-    key: drupal7db


### PR DESCRIPTION
MIGRATE_IGNORE_SITES needs to be carefully set: no spaces. 

MIGRATE_IGNORE_SITES=finance or MIGRATE_IGNORE_SITES=finance,communities for multiple depts.

Tested locally with users and nodes. Adding depts increases the ignored count each time, which is what we want. Also ignores if you pass the --update flag into migrate:import, which helps guarantee live data.