### PR TITLE
Dept 935

### DIFF
--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -145,6 +145,8 @@ process:
           source: fid
           entity_type: media
         -
+          plugin: media_value_filter
+        -
           plugin: default_value
           default_value: 97431
   field_publication_secure_files:
@@ -156,6 +158,8 @@ process:
           plugin: d7_file_lookup
           source: fid
           entity_type: media
+        -
+          - plugin: media_value_filter
         -
           plugin: default_value
           default_value: 97431

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration.node_publication.yml
@@ -120,6 +120,7 @@ process:
         - plugin: d7_file_lookup
           source: fid
           entity_type: media
+        - plugin: media_value_filter
         - plugin: default_value
           default_value: 97431
   field_publication_secure_files:
@@ -130,6 +131,7 @@ process:
         - plugin: d7_file_lookup
           source: fid
           entity_type: media
+        - plugin: media_value_filter
         - plugin: default_value
           default_value: 97431
   field_external_publication:

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/src/Plugin/migrate/source/d7/Node.php
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/src/Plugin/migrate/source/d7/Node.php
@@ -260,6 +260,8 @@ class Node extends FieldableEntity {
   public function getIds() {
     $ids['uuid']['type'] = 'string';
     $ids['nid']['type'] = 'integer';
+    $ids['nid']['alias'] = 'n';
+
     return $ids;
   }
 

--- a/web/modules/custom/dept_migrate/src/Plugin/migrate/process/MediaValueFilter.php
+++ b/web/modules/custom/dept_migrate/src/Plugin/migrate/process/MediaValueFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\dept_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filters missing or invalid media reference values.
+ *
+ * Example usage:
+ * @code
+ * process:
+ *   field_name:
+ *      -
+ *        plugin: media_value_filter
+ *        source: field_attachment
+ * @endcode
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "media_value_filter"
+ * )
+ */
+class MediaValueFilter extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    // Look through the values, filter out those which are arrays as these
+    // signify a lookup failure.
+    if (is_array($value)) {
+      return NULL;
+    }
+    else {
+      return $value;
+    }
+  }
+
+}


### PR DESCRIPTION
A minority of publication nodes contain references to D7 files which no longer exist in the file_managed table, or on disk. In D10 these files no longer exist either but when processing these dud references, it results in a lookup return that contains an array of just the original value passed back which breaks the field save process. A cryptic "not a valid entity" message is shown but that's about it.

This extra process filter strips out those weird instances. Ideally this just needs to be fixed in the source data before migration, or broken publications can be patched up by an editor after launch... site owners can decide what works best for them.