### PR TITLE
Adjust config for publication migration

### DIFF
--- a/config/sync/migrate_plus.migration.node_publication.yml
+++ b/config/sync/migrate_plus.migration.node_publication.yml
@@ -159,8 +159,7 @@ process:
           source: fid
           entity_type: media
         -
-          -
-            plugin: media_value_filter
+          plugin: media_value_filter
         -
           plugin: default_value
           default_value: 97431

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration_group.migrate_nodes.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_nodes/config/install/migrate_plus.migration_group.migrate_nodes.yml
@@ -6,6 +6,3 @@ label: 'Departmental sites - Nodes'
 description: 'Migrate nodes'
 source_type: 'Drupal 7'
 module: null
-shared_configuration:
-  source:
-    key: drupal7db


### PR DESCRIPTION
Migrate tools appears to have changed how it applies any shared configuration between migrations: https://www.drupal.org/node/3263258

Now that both drupal7db and main db occupy the same service, I don't think this config is needed. Tested on independent feature branch on PSH and the errors seen before no longer appear.