### PR TITLE
Skip users that already exist in D10

### DIFF
--- a/config/sync/migrate_plus.migration.users.yml
+++ b/config/sync/migrate_plus.migration.users.yml
@@ -32,6 +32,15 @@ process:
       value:
         - connollyl
         - nw_test_author
+    -
+      plugin: entity_lookup
+      entity_type: user
+      value_key: name
+      ignore_case: true
+    -
+      plugin: skip_on_condition
+      method: row
+      condition: empty
   pass: pass
   mail: mail
   created: created

--- a/web/modules/custom/dept_migrate/modules/dept_migrate_users/config/install/migrate_plus.migration.users.yml
+++ b/web/modules/custom/dept_migrate/modules/dept_migrate_users/config/install/migrate_plus.migration.users.yml
@@ -26,6 +26,13 @@ process:
       value:
         - connollyl
         - nw_test_author
+    - plugin: entity_lookup
+      entity_type: user
+      value_key: name
+      ignore_case: true
+    - plugin: skip_on_condition
+      method: row
+      condition: empty
   pass: pass
   mail: mail
   created: created


### PR DESCRIPTION
Appears to sometimes happen when a user moves department, eg uid 1232 (moved from daera to health according to email addresses)