### PR TITLE
Rely on config override for PSH URL

### DIFF
--- a/web/modules/custom/dept_core/src/Entity/Department.php
+++ b/web/modules/custom/dept_core/src/Entity/Department.php
@@ -271,7 +271,6 @@ class Department extends RevisionableContentEntityBase implements DepartmentInte
    */
   public function url(string $environment = 'active', bool $secure_protocol = TRUE): string {
     $hostname = $this->hostname();
-    
     return ($secure_protocol ? "https://" : "http://") . $hostname;
   }
 

--- a/web/modules/custom/dept_core/src/Entity/Department.php
+++ b/web/modules/custom/dept_core/src/Entity/Department.php
@@ -271,18 +271,7 @@ class Department extends RevisionableContentEntityBase implements DepartmentInte
    */
   public function url(string $environment = 'active', bool $secure_protocol = TRUE): string {
     $hostname = $this->hostname();
-    // Situational override: if we know we're on a development environment of
-    // PSH where the hostname can vary by git branch name; exceeds what
-    // config_split can accommodate.
-    if (!empty(getenv('PLATFORM_BRANCH') && (getenv('PLATFORM_ENVIRONMENT_TYPE') === 'development'))) {
-      $dept_site = explode('.', $hostname)[0];
-      $hostname = sprintf("%s.%s-%s.%s.platformsh.site",
-        $dept_site,
-        getenv('PLATFORM_ENVIRONMENT'),
-        getenv('PLATFORM_PROJECT'),
-        'uk-1');
-    }
-
+    
     return ($secure_protocol ? "https://" : "http://") . $hostname;
   }
 


### PR DESCRIPTION
This appears to be redundant as the underlying hostname() call makes use of the config override in there.