### PR TITLE
Skip canonical user entity path rewriting

### DIFF
--- a/config/sync/domain_source.settings.yml
+++ b/config/sync/domain_source.settings.yml
@@ -2,18 +2,20 @@ _core:
   default_config_hash: mqVsLCNF_WfM-XDhZ0nuTWd7bjvrqR5a6K_-vd0bwjU
 exclude_routes:
   canonical: canonical
-  delete_form: '0'
-  delete_multiple_form: '0'
-  edit_form: '0'
-  version_history: '0'
-  revision: '0'
-  create: '0'
-  book_outline_form: '0'
-  book_remove_form: '0'
-  scheduled_transitions: '0'
-  scheduled_transition_add: '0'
-  latest_version: '0'
-  devel_load: '0'
-  devel_render: '0'
-  devel_definition: '0'
-  token_devel: '0'
+  delete_form: delete_form
+  delete_multiple_form: delete_multiple_form
+  edit_form: edit_form
+  version_history: version_history
+  revision: revision
+  create: create
+  book_outline_form: book_outline_form
+  book_remove_form: book_remove_form
+  scheduled_transitions: scheduled_transitions
+  scheduled_transition_add: scheduled_transition_add
+  latest_version: latest_version
+  devel_load: devel_load
+  devel_load_with_references: devel_load_with_references
+  devel_path_alias: devel_path_alias
+  devel_render: devel_render
+  devel_definition: devel_definition
+  token_devel: token_devel

--- a/config/sync/field.field.user.user.field_domain_source.yml
+++ b/config/sync/field.field.user.user.field_domain_source.yml
@@ -11,6 +11,18 @@ third_party_settings:
   domain_entity:
     exclude_routes:
       canonical: canonical
+      edit_form: edit_form
+      cancel_form: cancel_form
+      collection: collection
+      scheduled_transitions: scheduled_transitions
+      scheduled_transition_add: scheduled_transition_add
+      devel_load: devel_load
+      devel_load_with_references: devel_load_with_references
+      devel_path_alias: devel_path_alias
+      devel_render: devel_render
+      devel_definition: devel_definition
+      masquerade: masquerade
+      token_devel: token_devel
 id: user.user.field_domain_source
 field_name: field_domain_source
 entity_type: user


### PR DESCRIPTION
Means admins can edit users on the currently logged in domain instead of having to log in to the other dept first. Only affects user entities to aid in making the user listing more easy to use