### PR TITLE
Allow authenticated users to view registered/active domains

### DIFF
--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -7,6 +7,7 @@ dependencies:
     - search_api_autocomplete.search.search
     - taxonomy.vocabulary.global_topics
   module:
+    - domain
     - domain_access
     - domain_entity
     - filter
@@ -38,7 +39,9 @@ permissions:
   - 'use moderation sidebar'
   - 'use search_api_autocomplete for search'
   - 'use text format basic_html'
+  - 'view assigned domains'
   - 'view content references'
+  - 'view domain list'
   - 'view media'
   - 'view own unpublished content'
   - 'view term names in global_topics'

--- a/web/modules/custom/dept_core/dept_core.module
+++ b/web/modules/custom/dept_core/dept_core.module
@@ -426,7 +426,7 @@ function dept_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
       $user_domains = $current_user->get('field_domain_access')->referencedEntities();
 
       // If the user doesn't have top level domain permissions or no assigned domains, hide this filter option.
-      if (!\Drupal::currentUser()->hasPermission('administer domains') || empty($user_domains)) {
+      if (empty($user_domains)) {
         $form['dept']['#value'] = $current_dept->id();
         hide($form['dept']);
         return;


### PR DESCRIPTION
Permits non-admin users to see the department exposed filter. Domain access otherwise will hide the options