### PR TITLE
A11y tweaks for logos

### DIFF
--- a/web/themes/custom/nicsdru_dept_theme/images/logo-communities.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-communities.svg
@@ -1,10 +1,14 @@
-<svg width="697" height="86" viewBox="0 0 697 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="697" height="86" viewBox="0 0 697 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department for Communities</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
-  <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
+  <g transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(125, 85, 199);"/>
     <path d="M 51.182 30.4 L 64.092 37.854 L 64.092 52.761 L 51.182 60.214 L 38.272 52.761 L 38.272 37.854 L 51.182 30.4 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(125, 85, 199);"/>
     <path d="M 51.182 60.214 L 64.092 67.667 L 64.092 82.574 L 51.182 90.028 L 38.272 82.575 L 38.272 67.667 L 51.182 60.214 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(20, 32, 98);"/>
@@ -20,12 +24,14 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(125, 85, 199);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(125, 85, 199);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.916" y="13">Department for</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="83.308" y="54">Communities</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 329 1.233 L 329 66.233"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="346.492" y="13">An Roinn</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="343" y="54">Pobal</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 454 1.233 L 454 66.233"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="470.276" y="13">Depairtment fur</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="468.5" y="54">Commonities</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.916" y="13">Department for</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Communities</text>
+    <path style="stroke: rgb(0, 0, 0);" d="M 329 1.233 L 329 66.233"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="346.492" y="13">An Roinn</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="343" y="54">Pobal</text>
+    <path style="stroke: rgb(0, 0, 0);" d="M 454 1.233 L 454 66.233"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="470.276" y="13">Depairtment fur</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="468.5" y="54">Commonities</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-daera.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-daera.svg
@@ -1,21 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1173" height="96" viewBox="0 0 1173 96" preserveAspectRatio="xMinYMin meet">
-    <title>Department of Agriculture, Environment and Rural Affairs</title>
-    <defs><style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style></defs><path fill="#00aa4f" d="m35.5.5 8.9 5.1v10.3L35.5 21l-8.9-5.1V5.7zm0 20.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V26.3zm34.9-.1v20.6l-8.2-5.1V26.3l8.2-5.1zm0 20.6v20.6l-8.2-5.1V46.9l8.2-5.1zM53.3 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zm0 20.5 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zm0 20.6 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1z"/><path fill="#142062" d="m35.5 41.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V46.8zm0 20.6 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V67.4zM17.7 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zm0 20.5 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zm0 20.6 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM.5 21.1v20.6l8.2-5.1V26.3zm0 20.7v20.6l8.2-5.1V47z"/><g fill="#142062"><text x="87" y="13" font-family="'Libre Franklin', Helvetica" font-size="14" style="white-space:pre;letter-spacing:-.2px">
+<svg role="img" width="1173" height="96" viewBox="0 0 1173 96" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+  <title>Department of Agriculture, Environment and Rural Affairs</title>
+  <defs>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 32px; word-spacing: 4px; letter-spacing:-1.1px; white-space: nowrap;}
+    </style>
+  </defs>
+  <g fill="#00aa4f">
+    <path d="m35.5.5 8.9 5.1v10.3L35.5 21l-8.9-5.1V5.7zM35.5 21.2l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V26.3zM53.3 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM53.3 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM53.3 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM70.4 21.1v20.6l-8.2-5.1V26.3l8.2-5.1zM70.4 41.7v20.6l-8.2-5.1V46.9l8.2-5.1z"/>
+  </g>
+  <g fill="#142062">
+    <path d="m35.5 41.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V46.8zM35.5 62.3l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V67.4zM17.7 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM17.7 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM17.7 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM.5 21.1v20.6l8.2-5.1V26.3zM.5 41.8v20.6l8.2-5.1V47z"/>
+  </g>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="87" y="13">
       <tspan x="87" y="13">Department of</tspan>
-    </text><text x="84" y="48.1" font-family="'Libre Bodoni', Georgia" font-size="32" style="white-space:pre;word-spacing:4px;letter-spacing:-1.1px">
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" x="84" y="48.1">
       <tspan x="84.7" y="48.1">Agriculture, Environment</tspan>
-    </text><text x="85" y="84.1" font-family="'Libre Bodoni', Georgia" font-size="32" style="white-space:pre;word-spacing:4px;letter-spacing:-1.1px">
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" x="85" y="84.1">
       <tspan x="85" y="84.1">and Rural Affairs</tspan>
-    </text><path stroke="#142062" d="M452 0v94"/><text x="470" y="13" font-family="'Libre Franklin', Helvetica" font-size="14" style="white-space:pre;letter-spacing:-.2px">
+    </text>
+    <path stroke="#142062" d="M452 0v94"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="470" y="13">
       <tspan x="470" y="13">An Roinn</tspan>
-    </text><text x="468" y="48.1" font-family="'Libre Bodoni', Georgia" font-size="32" style="white-space:pre;word-spacing:4px;letter-spacing:-1.1px">
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" x="468" y="48.1">
       <tspan x="468" y="48.1">Talmhaíochta, Comhshaoil</tspan>
-    </text><text x="468" y="84.1" font-family="'Libre Bodoni', Georgia" font-size="32" style="white-space:pre;word-spacing:4px;letter-spacing:-1.1px">
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" x="468" y="84.1">
       <tspan x="468" y="84.1">agus Gnóthaí Tuaithe</tspan>
-    </text><path stroke="#142062" d="M850 0v94"/><text x="867" y="13" font-family="'Libre Franklin', Helvetica" font-size="14" style="white-space:pre;letter-spacing:-.2px">
+    </text>
+    <path stroke="#142062" d="M850 0v94"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="867" y="13">
       <tspan x="867" y="13">Depairtment o&apos;</tspan>
-    </text><text x="865" y="48.1" font-family="'Libre Bodoni', Georgia" font-size="32" style="white-space:pre;word-spacing:4px;letter-spacing:-1.1px">
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" x="865" y="48.1">
       <tspan x="865" y="48.1">Fairmin, Environment</tspan>
-    </text><text x="866" y="84.1" font-family="'Libre Bodoni', Georgia" font-size="32" style="white-space:pre;word-spacing:4px;letter-spacing:-1.1px">
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" x="866" y="84.1">
       <tspan x="866" y="84.1">an&apos; Kintra Matthers</tspan>
-    </text></g></svg>
+    </text>
+  </g>
+</svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-daera.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-daera.svg
@@ -15,34 +15,16 @@
     <path d="m35.5 41.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V46.8zM35.5 62.3l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V67.4zM17.7 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM17.7 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM17.7 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM.5 21.1v20.6l8.2-5.1V26.3zM.5 41.8v20.6l8.2-5.1V47z"/>
   </g>
   <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
-    <text role="presentation" class="svg-logo-txt-sm" x="87" y="13">
-      <tspan x="87" y="13">Department of</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" x="84" y="48.1">
-      <tspan x="84.7" y="48.1">Agriculture, Environment</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" x="85" y="84.1">
-      <tspan x="85" y="84.1">and Rural Affairs</tspan>
-    </text>
+    <text role="presentation" class="svg-logo-txt-sm" x="87" y="13">Department of</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="84" y="48.1">Agriculture, Environment</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="85" y="84.1">and Rural Affairs</text>
     <path stroke="#142062" d="M452 0v94"/>
-    <text role="presentation" class="svg-logo-txt-sm" x="470" y="13">
-      <tspan x="470" y="13">An Roinn</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" x="468" y="48.1">
-      <tspan x="468" y="48.1">Talmhaíochta, Comhshaoil</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" x="468" y="84.1">
-      <tspan x="468" y="84.1">agus Gnóthaí Tuaithe</tspan>
-    </text>
+    <text role="presentation" class="svg-logo-txt-sm" x="470" y="13">An Roinn</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="468" y="48.1">Talmhaíochta, Comhshaoil</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="468" y="84.1">agus Gnóthaí Tuaithe</text>
     <path stroke="#142062" d="M850 0v94"/>
-    <text role="presentation" class="svg-logo-txt-sm" x="867" y="13">
-      <tspan x="867" y="13">Depairtment o&apos;</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" x="865" y="48.1">
-      <tspan x="865" y="48.1">Fairmin, Environment</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" x="866" y="84.1">
-      <tspan x="866" y="84.1">an&apos; Kintra Matthers</tspan>
-    </text>
+    <text role="presentation" class="svg-logo-txt-sm" x="867" y="13">Depairtment o&apos;</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="865" y="48.1">Fairmin, Environment</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="866" y="84.1">an&apos; Kintra Matthers</text>
   </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-economy.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-economy.svg
@@ -15,18 +15,10 @@
     <path d="m35.5 41.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V46.8zM35.5 62.3l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V67.4zM17.7 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM17.7 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM17.7 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM.5 21.1v20.6l8.2-5.1V26.3zM.5 41.8v20.6l8.2-5.1V47z"/>
   </g>
   <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
-    <text role="presentation" class="svg-logo-txt-sm" transform="translate(86.9 13)">
-      <tspan x="0" y="0">Department for the</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" transform="translate(83.3 54)">
-      <tspan x="0" y="0">Economy</tspan>
-    </text>
+    <text role="presentation" class="svg-logo-txt-sm" transform="translate(86.9 13)">Department for the</text>
+    <text role="presentation" class="svg-logo-txt-lg" transform="translate(83.3 54)">Economy</text>
     <path stroke="#000" d="M263.5 0v65"/>
-    <text role="presentation" class="svg-logo-txt-sm" transform="translate(281.5 13)">
-      <tspan x="0" y="0">An Roinn</tspan>
-    </text>
-    <text role="presentation" class="svg-logo-txt-lg" transform="translate(279.6 54)">
-      <tspan x="0" y="0">Geilleagair</tspan>
-    </text>
+    <text role="presentation" class="svg-logo-txt-sm" transform="translate(281.5 13)">An Roinn</text>
+    <text role="presentation" class="svg-logo-txt-lg" transform="translate(279.6 54)">Geilleagair</text>
   </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-economy.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-economy.svg
@@ -1,11 +1,32 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="468" height="86" viewBox="0 0 468 86">
+<svg role="img" width="468" height="86" viewBox="0 0 468 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department for the Economy</title>
-  <defs><style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style></defs><g fill="#2b78c6"><path d="m35.5.5 8.9 5.1v10.3L35.5 21l-8.9-5.1V5.7zM35.5 21.2l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V26.3zM53.3 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM53.3 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM53.3 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM70.4 21.1v20.6l-8.2-5.1V26.3l8.2-5.1zM70.4 41.7v20.6l-8.2-5.1V46.9l8.2-5.1z"/></g><g fill="#142062"><path d="m35.5 41.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V46.8zM35.5 62.3l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V67.4zM17.7 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM17.7 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM17.7 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM.5 21.1v20.6l8.2-5.1V26.3zM.5 41.8v20.6l8.2-5.1V47z"/></g><text fill="#142062" font-family="'Libre Franklin', Helvetica" font-size="14" style="letter-spacing:-.2px" transform="translate(86.9 13)">
-    <tspan x="0" y="0">Department for the</tspan>
-  </text><text fill="#142062" font-family="'Libre Bodoni', Georgia" font-size="40" style="word-spacing:4px;letter-spacing:-1.1px" transform="translate(83.3 54)">
-    <tspan x="0" y="0">Economy</tspan>
-  </text><path fill="#142062" stroke="#000" d="M263.5 0v65"/><text fill="#142062" font-family="'Libre Franklin', Helvetica" font-size="14" style="letter-spacing:-.2px" transform="translate(281.5 13)">
-    <tspan x="0" y="0">An Roinn</tspan>
-  </text><text fill="#142062" font-family="'Libre Bodoni', Georgia" font-size="40" style="word-spacing:4px;letter-spacing:-1.1px" transform="translate(279.6 54)">
-    <tspan x="0" y="0">Geilleagair</tspan>
-  </text></svg>
+  <defs>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
+  </defs>
+  <g fill="#2b78c6">
+    <path d="m35.5.5 8.9 5.1v10.3L35.5 21l-8.9-5.1V5.7zM35.5 21.2l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V26.3zM53.3 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM53.3 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM53.3 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM70.4 21.1v20.6l-8.2-5.1V26.3l8.2-5.1zM70.4 41.7v20.6l-8.2-5.1V46.9l8.2-5.1z"/>
+  </g>
+  <g fill="#142062">
+    <path d="m35.5 41.7 8.9 5.1v10.3l-8.9 5.1-8.9-5.1V46.8zM35.5 62.3l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V67.4zM17.7 10.9l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V16zM17.7 31.4l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V36.5zM17.7 52l8.9 5.1v10.3l-8.9 5.1-8.9-5.1V57.1zM.5 21.1v20.6l8.2-5.1V26.3zM.5 41.8v20.6l8.2-5.1V47z"/>
+  </g>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" transform="translate(86.9 13)">
+      <tspan x="0" y="0">Department for the</tspan>
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" transform="translate(83.3 54)">
+      <tspan x="0" y="0">Economy</tspan>
+    </text>
+    <path stroke="#000" d="M263.5 0v65"/>
+    <text role="presentation" class="svg-logo-txt-sm" transform="translate(281.5 13)">
+      <tspan x="0" y="0">An Roinn</tspan>
+    </text>
+    <text role="presentation" class="svg-logo-txt-lg" transform="translate(279.6 54)">
+      <tspan x="0" y="0">Geilleagair</tspan>
+    </text>
+  </g>
+</svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-education.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-education.svg
@@ -1,8 +1,12 @@
-<svg width="260" height="86" viewBox="0 0 260 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="260" height="86" viewBox="0 0 260 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department of Education</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
   <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(202, 44, 146);"/>
@@ -20,6 +24,8 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(202, 44, 146);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(202, 44, 146);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.916" y="13">Department of</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="83.308" y="54">Education</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.916" y="13">Department of</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Education</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-executiveoffice.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-executiveoffice.svg
@@ -1,8 +1,12 @@
-<svg width="361" height="86" viewBox="0 0 361 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="361" height="86" viewBox="0 0 361 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>The Executive Office</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
   <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(59, 128, 174);"/>
@@ -20,6 +24,8 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(59, 128, 174);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(59, 128, 174);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.5" y="13">The</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="83.308" y="54">Executive Office</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.5" y="13">The</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Executive Office</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-finance.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-finance.svg
@@ -1,8 +1,12 @@
-<svg width="430" height="86" viewBox="0 0 430 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="430" height="86" viewBox="0 0 430 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department of Finance</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
   <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(115, 123, 69);"/>
@@ -20,9 +24,11 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(115, 123, 69);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(115, 123, 69);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.916" y="13">Department of</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="83.308" y="54">Finance</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 237.5 0 L 237.5 65"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="253.492" y="13">An Roinn</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="251.55" y="54">Airgeadais</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.916" y="13">Department of</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Finance</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 237.5 0 L 237.5 65"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="253.492" y="13">An Roinn</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="251.55" y="54">Airgeadais</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-health.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-health.svg
@@ -1,8 +1,12 @@
-<svg width="370" height="86" viewBox="0 0 370 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="370" height="86" viewBox="0 0 370 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department of Health</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
   <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(1, 147, 166);"/>
@@ -20,10 +24,12 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(17, 147, 166);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(17, 147, 166);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.916" y="13">Department of</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="83.308" y="54">Health</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 212.5 0 L 212.5 65"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="230.492" y="13">An Roinn Sláinte</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 300.647 -45.334 L 300.647 94" transform="matrix(0, -1, 1, 0, 275.826004, 325.468002)"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="229.492" y="45">Männystrie O Pouste</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.916" y="13">Department of</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Health</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 212.5 0 L 212.5 65"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="230.492" y="13">An Roinn Sláinte</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 300.647 -45.334 L 300.647 94" transform="matrix(0, -1, 1, 0, 275.826004, 325.468002)"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="229.492" y="45">Männystrie O Pouste</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-infrastructure.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-infrastructure.svg
@@ -1,8 +1,12 @@
-<svg width="815" height="86" preserveAspectRatio="xMinYMin meet" viewBox="0 0 815 86" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="815" height="86" viewBox="0 0 815 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department for Infrastructure</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
   <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(255, 184, 28);"/>
@@ -20,12 +24,14 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(255, 184, 28);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(255, 184, 28);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.916" y="13">Department for</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: pre;" x="83.308" y="54">Infrastructure</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 337 1.233 L 337 66.233"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: pre; font-size: 14px;" x="354.492" y="13">An Roinn</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: pre;" x="351" y="54">Bonneagair</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 564 1.233 L 564 66.233"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: pre; font-size: 14px;" x="579.276" y="13">Depairtment fur</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: pre;" x="577.5" y="54">Infrastructure</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.916" y="13">Department for</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Infrastructure</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 337 1.233 L 337 66.233"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="354.492" y="13">An Roinn</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="351" y="54">Bonneagair</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(0, 0, 0);" d="M 564 1.233 L 564 66.233"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="579.276" y="13">Depairtment fur</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="577.5" y="54">Infrastructure</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-justice.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-justice.svg
@@ -1,10 +1,14 @@
-<svg width="370" height="86" viewBox="0 0 370 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="370" height="86" viewBox="0 0 370 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Department of Justice</title>
   <defs>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
-    <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);</style>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Libre+Franklin%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&amp;display=swap);
+      .svg-logo-txt-sm {font-family: "Libre Franklin", sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;}
+      .svg-logo-txt-lg {font-family: "Libre Bodoni", Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;}
+    </style>
   </defs>
-  <g style="" transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
+  <g transform="matrix(0.689608, 0, 0, 0.689608, 0.162956, 0.198013)">
     <path d="M 51.182 0.504 L 64.092 7.958 L 64.092 22.865 L 51.182 30.318 L 38.272 22.865 L 38.272 7.958 L 51.182 0.504 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(137, 59, 103);"/>
     <path d="M 51.182 30.4 L 64.092 37.854 L 64.092 52.761 L 51.182 60.214 L 38.272 52.761 L 38.272 37.854 L 51.182 30.4 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(137, 59, 103);"/>
     <path d="M 51.182 60.214 L 64.092 67.667 L 64.092 82.574 L 51.182 90.028 L 38.272 82.575 L 38.272 67.667 L 51.182 60.214 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(20, 32, 98);"/>
@@ -20,10 +24,12 @@
     <path d="M 101.822 30.318 C 101.869 45.316 101.804 60.134 101.822 60.132 L 89.912 52.679 L 89.912 37.772 L 101.822 30.318 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(137, 59, 103);"/>
     <path d="M 101.822 60.132 C 101.869 75.13 101.804 89.948 101.822 89.946 L 89.912 82.493 L 89.912 67.586 L 101.822 60.132 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(137, 59, 103);"/>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="86.916" y="13">Department of</text>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 40px; letter-spacing: -1.5px; white-space: nowrap;" x="83.308" y="54">Justice</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 212.5 0 L 212.5 65"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="230.492" y="13">An Roinn Dlí agus Cirt</text>
-  <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 300.647 -45.334 L 300.647 94" transform="matrix(0, -1, 1, 0, 275.826004, 325.468002)"/>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Franklin&quot;, sans-serif; letter-spacing: -0.2px; white-space: nowrap; font-size: 14px;" x="229.492" y="45">Männystrie O tha Laa</text>
+  <g style="fill: rgb(20, 32, 98);" aria-hidden="true">
+    <text role="presentation" class="svg-logo-txt-sm" x="86.916" y="13">Department of</text>
+    <text role="presentation" class="svg-logo-txt-lg" x="83.308" y="54">Justice</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 212.5 0 L 212.5 65"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="230.492" y="13">An Roinn Dlí agus Cirt</text>
+    <path style="fill: rgb(20, 32, 98); stroke: rgb(20, 32, 98);" d="M 300.647 -45.334 L 300.647 94" transform="matrix(0, -1, 1, 0, 275.826004, 325.468002)"/>
+    <text role="presentation" class="svg-logo-txt-sm" x="229.492" y="45">Männystrie O tha Laa</text>
+  </g>
 </svg>

--- a/web/themes/custom/nicsdru_dept_theme/images/logo-nigov.svg
+++ b/web/themes/custom/nicsdru_dept_theme/images/logo-nigov.svg
@@ -1,4 +1,4 @@
-<svg width="330" height="86" viewBox="0 0 330 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
+<svg role="img" width="330" height="86" viewBox="0 0 330 86" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
   <title>Northern Ireland Executive</title>
   <defs>
     <style>@import url(https://fonts.googleapis.com/css2?family=Libre+Bodoni%3Aital%2Cwght%400%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700&amp;display=swap);</style>
@@ -24,5 +24,5 @@
       <path d="M 12.435 90.11 C 12.482 75.112 12.417 60.294 12.435 60.296 L 0.525 67.749 L 0.525 82.656 L 12.435 90.11 Z" transform="matrix(-1, 0, 0, -1, 12.977422, 150.405998)"/>
     </g>
   </g>
-  <text style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 34px; letter-spacing: -1.5px; white-space: nowrap;" transform="matrix(1, 0, 0, 1, 4, -25)"><tspan x="83.308" y="54">Northern Ireland</tspan><tspan x="83.308" dy="1em">​</tspan><tspan>Executive</tspan></text>
+  <text role="presentation" aria-hidden="true" style="fill: rgb(20, 32, 98); font-family: &quot;Libre Bodoni&quot;, Georgia; font-size: 34px; letter-spacing: -1.5px; white-space: nowrap;" transform="matrix(1, 0, 0, 1, 4, -25)"><tspan x="83.308" y="54">Northern Ireland</tspan><tspan x="83.308" dy="1em">​</tspan><tspan>Executive</tspan></text>
 </svg>


### PR DESCRIPTION
Ensure screen readers only read the title element and ignore text elements:
- add role="img"
- add role="presentation" to text elements
- apply aria-hidden to <g> wrapper for text elements
- use css classes for text styling rather than style attributes