### PR TITLE
Dept 1102

### DIFF
--- a/config/sync/user.role.supervisor.yml
+++ b/config/sync/user.role.supervisor.yml
@@ -29,6 +29,7 @@ dependencies:
     - dept_topics
     - domain_access
     - domain_entity
+    - file
     - media
     - node
     - origins_workflow
@@ -79,6 +80,7 @@ permissions:
   - 'create secure_file media content on assigned domains'
   - 'create ual content on assigned domains'
   - 'delete all revisions'
+  - 'delete any file'
   - 'delete application content on assigned domains'
   - 'delete application revisions'
   - 'delete article content on assigned domains'

--- a/config/sync/views.view.files.yml
+++ b/config/sync/views.view.files.yml
@@ -475,6 +475,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: 0
           id: 0
@@ -492,7 +493,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -531,7 +531,7 @@ display:
           entity_type: file
           entity_field: filename
           plugin_id: string
-          operator: word
+          operator: contains
           value: ''
           group: 1
           exposed: true
@@ -549,8 +549,19 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
+              admin: '0'
               administrator: '0'
+              anonymous: '0'
+              author: '0'
+              supervisor: '0'
+              homepage_supervisor: '0'
+              rss_supervisor: '0'
+              stats_author: '0'
+              stats_supervisor: '0'
+              topic_layout_supervisor: '0'
+              topic_supervisor: '0'
+              qa: '0'
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -1014,6 +1025,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: 0
           id: 0
@@ -1028,7 +1040,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       empty: {  }
       arguments:
         fid:


### PR DESCRIPTION
- Supervisors can now also delete underlying files behind media entities. The UI element is hidden but without this permission the media entity is deleted but the file, usually because it's owned by another user, remains on disk (not even marked as temporary for later deletion). This matches NIDirect's configuration as well.
- File view UI tweaked to make filename search more intuitive (contains any word gives :bat: :hankey: results)