### PR TITLE
Improve user profile display page

### DIFF
--- a/config/sync/core.entity_form_display.user.user.default.yml
+++ b/config/sync/core.entity_form_display.user.user.default.yml
@@ -8,10 +8,7 @@ dependencies:
     - field.field.user.user.field_domain_all_affiliates
     - field.field.user.user.field_domain_source
     - field.field.user.user.user_picture
-    - image.style.thumbnail
   module:
-    - image
-    - path
     - user
 _core:
   default_config_hash: K-1rBM8mTIkFp9RqOC2tMRUukOQ1xbRCfSKK8dEddnA
@@ -21,58 +18,35 @@ bundle: user
 mode: default
 content:
   account:
-    weight: -10
+    weight: 0
     region: content
+    settings: {  }
+    third_party_settings: {  }
   contact:
     weight: 5
     region: content
   field_domain_access:
     type: options_buttons
-    weight: 40
+    weight: 1
     region: content
     settings: {  }
-    third_party_settings: {  }
-  field_domain_admin:
-    type: options_buttons
-    weight: 50
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_domain_all_affiliates:
-    type: boolean_checkbox
-    weight: 41
-    region: content
-    settings:
-      display_label: true
     third_party_settings: {  }
   field_domain_source:
     type: options_select
-    weight: 51
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  language:
-    weight: 0
-    region: content
-  path:
-    type: path
-    weight: 30
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   timezone:
     weight: 6
     region: content
-  user_picture:
-    type: image_image
-    weight: -1
-    region: content
-    settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
-    third_party_settings: {  }
 hidden:
   entitygroupfield: true
+  field_domain_admin: true
+  field_domain_all_affiliates: true
   groups: true
   groups_type_department_site: true
   langcode: true
+  language: true
+  path: true
+  user_picture: true

--- a/config/sync/core.entity_view_display.user.user.full.yml
+++ b/config/sync/core.entity_view_display.user.user.full.yml
@@ -1,21 +1,50 @@
-uuid: f5b37467-e9f0-4c43-b302-fd810467eaa4
+uuid: 8dfb9f5f-768f-4c14-9af1-55c98136d30f
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.user.full
     - field.field.user.user.field_domain_access
     - field.field.user.user.field_domain_admin
     - field.field.user.user.field_domain_all_affiliates
     - field.field.user.user.field_domain_source
     - field.field.user.user.user_picture
   module:
+    - field_group
+    - layout_builder
     - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+  field_group:
+    group_departments:
+      children:
+        - field_domain_access
+        - field_domain_source
+      label: Departments
+      parent_name: ''
+      region: content
+      weight: 2
+      format_type: html_element
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: true
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
 _core:
   default_config_hash: V51QPCKkgNREKtSmB9Iu2wmAMEpktVpnzklWaZV8UYo
-id: user.user.default
+id: user.user.full
 targetEntityType: user
 bundle: user
-mode: default
+mode: full
 content:
   field_domain_access:
     type: entity_reference_label
@@ -23,7 +52,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_domain_source:
     type: entity_reference_label
@@ -31,12 +60,12 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   masquerade:
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 1
     region: content
   member_for:
     settings: {  }


### PR DESCRIPTION
Lists the depts a user can access and groups the user form fields more sensibly.

Result:

![image](https://github.com/user-attachments/assets/96b7adb9-a8c3-4720-bcd7-e3844ef3fe9d)

Could perhaps benefit from further improvement to bring tasks/tabs to the template to aid editing or other tasks.