### PR TITLE
Use changed property to improve natural sorting on content using publication date field

### DIFF
--- a/config/sync/search_api.index.consultations_index.yml
+++ b/config/sync/search_api.index.consultations_index.yml
@@ -13,9 +13,8 @@ dependencies:
     - field.storage.node.field_summary
     - search_api.server.default
   module:
-    - search_api_solr
     - node
-    - search_api
+    - search_api_solr
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -73,6 +72,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.body
+  changed:
+    label: Changed
+    datasource_id: 'entity:node'
+    property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
   field_consultation_dates:
     label: 'Consultation dates'
     datasource_id: 'entity:node'
@@ -214,6 +221,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: default

--- a/config/sync/search_api.index.news_index.yml
+++ b/config/sync/search_api.index.news_index.yml
@@ -7,15 +7,14 @@ dependencies:
     - field.storage.node.field_domain_access
     - field.storage.node.field_domain_source
     - field.storage.node.field_global_topics
-    - field.storage.node.field_summary
     - field.storage.node.field_news_type
     - field.storage.node.field_published_date
     - field.storage.node.field_site_topics
+    - field.storage.node.field_summary
     - search_api.server.default
   module:
-    - search_api_solr
     - node
-    - search_api
+    - search_api_solr
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -73,6 +72,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.body
+  changed:
+    label: Changed
+    datasource_id: 'entity:node'
+    property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
   field_domain_access:
     label: 'Domain Access'
     datasource_id: 'entity:node'
@@ -224,6 +231,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: default

--- a/config/sync/search_api.index.publications_index.yml
+++ b/config/sync/search_api.index.publications_index.yml
@@ -7,18 +7,17 @@ dependencies:
     - field.storage.node.field_domain_access
     - field.storage.node.field_domain_source
     - field.storage.node.field_global_topics
+    - field.storage.node.field_publication_type
     - field.storage.node.field_published_date
     - field.storage.node.field_site_topics
     - field.storage.node.field_summary
-    - field.storage.node.field_publication_type
     - search_api.server.default
   module:
-    - search_api_solr
-    - node
-    - user
-    - taxonomy
-    - search_api
     - flag_search_api
+    - node
+    - search_api_solr
+    - taxonomy
+    - user
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -76,6 +75,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.body
+  changed:
+    label: Changed
+    datasource_id: 'entity:node'
+    property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
   field_domain_access:
     label: 'Domain Access'
     datasource_id: 'entity:node'
@@ -299,6 +306,7 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: default

--- a/config/sync/views.view.content_by_site_subtopic.yml
+++ b/config/sync/views.view.content_by_site_subtopic.yml
@@ -848,6 +848,22 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
       filters:
         status:
           id: status
@@ -1169,6 +1185,22 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
       filters:
         status:
           id: status
@@ -1481,6 +1513,22 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: datetime
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
           order: DESC
           expose:
             label: ''

--- a/config/sync/views.view.news.yml
+++ b/config/sync/views.view.news.yml
@@ -144,6 +144,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 20
           total_pages: null
           id: 0
@@ -161,7 +162,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.news_search.yml
+++ b/config/sync/views.view.news_search.yml
@@ -43,6 +43,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 20
           total_pages: null
           id: 0
@@ -60,7 +61,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 5
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -79,19 +79,19 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        search_api_relevance:
-          id: search_api_relevance
+        field_published_date_1:
+          id: field_published_date_1
           table: search_api_index_news_index
-          field: search_api_relevance
+          field: field_published_date
           relationship: none
           group_type: group
           admin_label: ''
           plugin_id: search_api
           order: DESC
           expose:
-            label: Relevance
-            field_identifier: search_api_relevance
-          exposed: true
+            label: ''
+            field_identifier: ''
+          exposed: false
         field_published_date:
           id: field_published_date
           table: search_api_index_news_index
@@ -105,10 +105,23 @@ display:
             label: 'Publication date'
             field_identifier: field_published_date
           exposed: true
-        field_published_date_1:
-          id: field_published_date_1
+        search_api_relevance:
+          id: search_api_relevance
           table: search_api_index_news_index
-          field: field_published_date
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: Relevance
+            field_identifier: search_api_relevance
+          exposed: true
+        changed:
+          id: changed
+          table: search_api_index_news_index
+          field: changed
           relationship: none
           group_type: group
           admin_label: ''
@@ -1098,7 +1111,7 @@ display:
       display_extenders: {  }
       path: news
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
@@ -1108,8 +1121,6 @@ display:
         - url.site
         - 'user.node_grants:view'
       tags:
-        - 'config:facets.facet.news_publication_date'
-        - 'config:facets.facet.news_topic'
         - 'config:search_api.index.news_index'
         - 'search_api_list:news_index'
   press_release_search:
@@ -1336,7 +1347,7 @@ display:
       display_extenders: {  }
       path: press-releases
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
@@ -1346,9 +1357,6 @@ display:
         - url.site
         - 'user.node_grants:view'
       tags:
-        - 'config:facets.facet.pr_department'
-        - 'config:facets.facet.pr_publication_date'
-        - 'config:facets.facet.pr_topics'
         - 'config:search_api.index.news_index'
         - 'search_api_list:news_index'
   press_releases_feed:


### PR DESCRIPTION
Granularity on the date field in Solr doesn't seem sufficient to go past day comparison, so we introduce the changed timestamp to improve on this (for now) until some improvement can be made on Solr date handling (or views consumption of that data)