### PR TITLE
Dept 1193

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,7 +47,7 @@ relationships:
   database: 'db:dept'
 
 # The size of the persistent disk of the application (in MB).
-disk: 137216
+disk: 136704
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,7 +47,7 @@ relationships:
   database: 'db:dept'
 
 # The size of the persistent disk of the application (in MB).
-disk: 136704
+disk: 131072
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -47,7 +47,7 @@ relationships:
   database: 'db:dept'
 
 # The size of the persistent disk of the application (in MB).
-disk: 131072
+disk: 137216
 
 # The 'mounts' describe writable, persistent filesystem mounts in the application.
 mounts:

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -31,4 +31,4 @@ solr_8_11:
 
 redis:
   type: redis-persistent:7.2
-  disk: 512
+  disk: 6144

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -30,4 +30,5 @@ solr_8_11:
         core: default
 
 redis:
-  type: redis:6.0
+  type: redis-persistent:7.2
+  disk: 512

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -30,5 +30,6 @@ solr_8_11:
         core: default
 
 redis:
-  type: redis-persistent:7.2
-  disk: 6144
+  type: "redis:7.2"
+  configuration:
+    maxmemory_policy: allkeys-lfu


### PR DESCRIPTION
- Redis service is pre-sized by PSH (1GB for prod, 0.5GB for dev env)
- Persistent service offers no real benefit in this context
- Tweaking cache expiration policy to expire least frequently used keys seems like a useful thing to do