### PR TITLE
Dept 1201

### DIFF
--- a/config/sync/user.role.supervisor.yml
+++ b/config/sync/user.role.supervisor.yml
@@ -27,6 +27,7 @@ dependencies:
   module:
     - book
     - content_moderation
+    - dept_topics
     - domain_access
     - domain_entity
     - file

--- a/config/sync/user.role.topic_supervisor.yml
+++ b/config/sync/user.role.topic_supervisor.yml
@@ -28,6 +28,7 @@ permissions:
   - 'delete subtopic content on assigned domains'
   - 'delete topic content on assigned domains'
   - 'flag hide_listing'
+  - 'manage order of topic content'
   - 'publish to any assigned domain'
   - 'reschedule scheduled transitions node subtopic'
   - 'reschedule scheduled transitions node topic'

--- a/web/modules/custom/dept_topics/dept_topics.module
+++ b/web/modules/custom/dept_topics/dept_topics.module
@@ -44,7 +44,7 @@ function dept_topics_moderation_sidebar_alter(&$build, &$context) {
     in_array($context->bundle(), ['topic', 'subtopic'])) {
 
     // See also: dept_postprocess_moderation_sidebar_alter()
-    if (\Drupal::currentUser()->hasPermission('edit subtopic content')) {
+    if (\Drupal::currentUser()->hasPermission('manage order of topic content')) {
 
       $build['actions']['secondary']['info_topic_content'] = [
         '#theme' => 'moderation_sidebar_info_section',

--- a/web/modules/custom/dept_topics/dept_topics.permissions.yml
+++ b/web/modules/custom/dept_topics/dept_topics.permissions.yml
@@ -4,3 +4,6 @@ use topic tree widget:
 administer orphaned content:
   title: 'Administer orphaned content'
   restrict access: true
+
+manage order of topic content:
+  title: 'Manage order of topic content'

--- a/web/modules/custom/dept_topics/dept_topics.routing.yml
+++ b/web/modules/custom/dept_topics/dept_topics.routing.yml
@@ -21,4 +21,4 @@ dept_topics.manage_topic_content.form:
     _title: 'Manage topic content'
     _form: 'Drupal\dept_topics\Form\ManageTopicContentForm'
   requirements:
-    _role: 'topic_supervisor+administrator'
+    _permission: 'manage order of topic content'


### PR DESCRIPTION
Ensures that users given the Topic supervisor (Add-on role) role can manage the order of subtopics shown. Changed over from fixed roles to a single permission. The tweak in the module file also ensures it's added into the moderation sidebar links.