### PR TITLE
Exclude domain fields from front-end render

### DIFF
--- a/config/sync/core.entity_view_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_view_display.media.remote_video.default.yml
@@ -16,22 +16,6 @@ targetEntityType: media
 bundle: remote_video
 mode: default
 content:
-  field_domain_access:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 1
-    region: content
-  field_domain_source:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 2
-    region: content
   field_media_oembed_video:
     type: oembed
     label: hidden
@@ -45,6 +29,8 @@ content:
     region: content
 hidden:
   created: true
+  field_domain_access: true
+  field_domain_source: true
   langcode: true
   name: true
   search_api_excerpt: true


### PR DESCRIPTION
When embedding the default view mode seems to be used. Perhaps shouldn't but for now exclude the domain related fields from appearing at the front-end