### PR TITLE
DEPT-1252 fix for numerous 404s for manifest json files

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -174,7 +174,7 @@ web:
           allow: true
         '^/sitemap\.xml$':
           allow: true
-        '^\/themes\/custom\/.+\/favicons\/.+\.webmanifest$':
+        '^\/themes\/custom\/.+\/favicons\/manifest-.+\.json$':
           allow: true
           expires: 2w
         '^/\.well-known/security\.txt$':


### PR DESCRIPTION
Update pattern for rule to allow manifest-[dept].json files