### PR TITLE
Ensure secure file downloads can be cached by Fastly

### DIFF
--- a/web/modules/custom/dept_publications/dept_publications.module
+++ b/web/modules/custom/dept_publications/dept_publications.module
@@ -155,9 +155,27 @@ function dept_publications_entity_operation_alter(array &$operations, EntityInte
  * Implements hook_file_download().
  */
 function dept_publications_file_download($uri) {
-  // Return -1 which is then later converted to AccessDeniedHttpException response.
-  if (\Drupal::service('secure_publications_file_access')->canAccessSecureFileAttachment($uri) === FALSE) {
-    return -1;
+
+  $access_service = \Drupal::service('secure_publications_file_access');
+
+  // Only apply to secure publication files in private storage.
+  if (str_starts_with($uri, 'private://') && $access_service->isSecurePublicationFile($uri)) {
+
+    // Prevent download if file embargoed.
+    if (!$access_service->canAccessSecureFileAttachment($uri)) {
+      // Return -1 which is then later converted to
+      // AccessDeniedHttpException response.
+      return -1;
+    }
+
+    // Ensure secure file download is cacheable by Fastly. This is
+    // necessary because files served from private:// are usually
+    // not cacheable.
+    return [
+      'Surrogate-Control' => 'public, max-age=604800, stale-while-revalidate=86400',
+      'Surrogate-Key' => 'secure-publication-file',
+    ];
+
   }
 }
 

--- a/web/modules/custom/dept_publications/dept_publications.services.yml
+++ b/web/modules/custom/dept_publications/dept_publications.services.yml
@@ -1,7 +1,7 @@
 services:
   secure_publications_file_access:
     class: Drupal\dept_publications\SecurePublicationsFileAccess
-    arguments: ['file_uri', '@current_user', '@database', '@entity_type.manager']
+    arguments: ['file_uri', '@current_user', '@database', '@entity_type.manager', '@cache.default']
   secure_publications.route_subscriber:
     class: Drupal\dept_publications\Routing\SecurePublicationsRouteSubscriber
     tags:

--- a/web/modules/custom/dept_publications/src/SecurePublicationsFileAccess.php
+++ b/web/modules/custom/dept_publications/src/SecurePublicationsFileAccess.php
@@ -32,6 +32,11 @@ class SecurePublicationsFileAccess {
   protected $entityTypeManager;
 
   /**
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
    * @param string $file_uri
    *   The URI of a file.
    * @param \Drupal\Core\Session\AccountInterface $user

--- a/web/modules/custom/dept_publications/src/SecurePublicationsFileAccess.php
+++ b/web/modules/custom/dept_publications/src/SecurePublicationsFileAccess.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dept_publications;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -39,12 +40,15 @@ class SecurePublicationsFileAccess {
    *   The database connection object.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service object.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   Cache backend object.
    */
-  public function __construct(string $file_uri, AccountInterface $user, Connection $connection, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(string $file_uri, AccountInterface $user, Connection $connection, EntityTypeManagerInterface $entity_type_manager, CacheBackendInterface $cache) {
     $this->fileUri = $file_uri;
     $this->user = $user;
     $this->connection = $connection;
     $this->entityTypeManager = $entity_type_manager;
+    $this->cache = $cache;
   }
 
   /**
@@ -90,6 +94,45 @@ class SecurePublicationsFileAccess {
     else {
       return FALSE;
     }
+  }
+
+  /**
+   * Check if a file URI is associated with a secure publication.
+   *
+   * @param string $uri
+   *   The file URI to check.
+   *
+   * @return bool
+   *   TRUE if the file is associated with a secure publication, FALSE otherwise.
+   */
+  public function isSecurePublicationFile(string $uri): bool {
+
+    if (!str_starts_with($uri, 'private://')) {
+      return FALSE;
+    }
+
+    static $static = [];
+
+    if (isset($static[$uri])) {
+      return $static[$uri];
+    }
+
+    $cid = 'secure_pub_file:' . hash('sha256', $uri);
+
+    if ($cache = $this->cache->get($cid)) {
+      return $static[$uri] = (bool) $cache->data;
+    }
+
+    $query = \Drupal::database()->select('file_managed', 'f');
+    $query->join('media__field_media_file_1', 'm', 'm.field_media_file_1_target_id = f.fid');
+    $query->condition('f.uri', $uri);
+    $query->range(0, 1);
+
+    $exists = (bool) $query->countQuery()->execute()->fetchField();
+
+    $this->cache->set($cid, $exists);
+
+    return $static[$uri] = $exists;
   }
 
 }


### PR DESCRIPTION
When Drupal serves files from private:// it adds response headers to ensure the file is not cached.  But since secure publication files can be served from private:// to the public, we do want the files to be cacheable and so we need to override headers Drupal sets.