### PR TITLE
DEPT-1327 Fix revisions overview pagination / missing revisions issue

### DIFF
--- a/web/modules/custom/dept_topics/dept_topics.install
+++ b/web/modules/custom/dept_topics/dept_topics.install
@@ -74,3 +74,16 @@ function dept_topics_update_8002() {
       }
     }
 }
+
+function dept_topics_update_8003(): string {
+  $database = \Drupal::database();
+
+  $updated = $database->update('node_field_revision')
+    ->fields([
+      'revision_translation_affected' => 1,
+    ])
+    ->isNull('revision_translation_affected')
+    ->execute();
+
+  return "Updated revision_translation_affected flag on {$updated} node_field_revision rows.";
+}

--- a/web/modules/custom/dept_topics/dept_topics.module
+++ b/web/modules/custom/dept_topics/dept_topics.module
@@ -291,6 +291,8 @@ function dept_topics_entity_delete(EntityInterface $entity) {
         if ($has_child_entry) {
           $topic_node->setRevisionLogMessage('Removed child: (' . $entity->id() . ') ' . $entity->label());
           $topic_node->setRevisionTranslationAffected(TRUE);
+          $topic_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+          $topic_node->setRevisionUserId(\Drupal::currentUser()->id());
           $topic_node->save();
         }
       }
@@ -376,6 +378,8 @@ function dept_topics_node_insert(NodeInterface $node) {
         'target_id' => $node->id()
       ]);
       $child_node->setRevisionTranslationAffected(TRUE);
+      $child_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+      $child_node->setRevisionUserId(\Drupal::currentUser()->id());
       $child_node->save();
     }
 

--- a/web/modules/custom/dept_topics/dept_topics.module
+++ b/web/modules/custom/dept_topics/dept_topics.module
@@ -290,6 +290,7 @@ function dept_topics_entity_delete(EntityInterface $entity) {
 
         if ($has_child_entry) {
           $topic_node->setRevisionLogMessage('Removed child: (' . $entity->id() . ') ' . $entity->label());
+          $topic_node->setRevisionTranslationAffected(TRUE);
           $topic_node->save();
         }
       }
@@ -374,6 +375,7 @@ function dept_topics_node_insert(NodeInterface $node) {
       $child_node->get('field_site_topics')->appendItem([
         'target_id' => $node->id()
       ]);
+      $child_node->setRevisionTranslationAffected(TRUE);
       $child_node->save();
     }
 

--- a/web/modules/custom/dept_topics/src/EventSubscriber/TopicsEntityEventSubscriber.php
+++ b/web/modules/custom/dept_topics/src/EventSubscriber/TopicsEntityEventSubscriber.php
@@ -84,6 +84,8 @@ final class TopicsEntityEventSubscriber implements EventSubscriberInterface {
                 }
               }
               $child_node->setRevisionTranslationAffected(TRUE);
+              $child_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+              $child_node->setRevisionUserId(\Drupal::currentUser()->id());
               $child_node->save();
 
               if ($child_topics->count() == 0) {
@@ -104,6 +106,8 @@ final class TopicsEntityEventSubscriber implements EventSubscriberInterface {
                   'target_id' => $entity->id()
                 ]);
                 $child_node->setRevisionTranslationAffected(TRUE);
+                $child_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+                $child_node->setRevisionUserId(\Drupal::currentUser()->id());
                 $child_node->save();
                 $this->orphanManager->removeOrphan($child_node);
               }
@@ -154,6 +158,8 @@ final class TopicsEntityEventSubscriber implements EventSubscriberInterface {
           }
         }
         $child_node->setRevisionTranslationAffected(TRUE);
+        $child_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+        $child_node->setRevisionUserId(\Drupal::currentUser()->id());
         $child_node->save();
 
         if ($child_topics->count() == 0) {

--- a/web/modules/custom/dept_topics/src/EventSubscriber/TopicsEntityEventSubscriber.php
+++ b/web/modules/custom/dept_topics/src/EventSubscriber/TopicsEntityEventSubscriber.php
@@ -83,6 +83,7 @@ final class TopicsEntityEventSubscriber implements EventSubscriberInterface {
                   $i--;
                 }
               }
+              $child_node->setRevisionTranslationAffected(TRUE);
               $child_node->save();
 
               if ($child_topics->count() == 0) {
@@ -102,6 +103,7 @@ final class TopicsEntityEventSubscriber implements EventSubscriberInterface {
                 $child_node->get('field_site_topics')->appendItem([
                   'target_id' => $entity->id()
                 ]);
+                $child_node->setRevisionTranslationAffected(TRUE);
                 $child_node->save();
                 $this->orphanManager->removeOrphan($child_node);
               }
@@ -151,6 +153,7 @@ final class TopicsEntityEventSubscriber implements EventSubscriberInterface {
             $i--;
           }
         }
+        $child_node->setRevisionTranslationAffected(TRUE);
         $child_node->save();
 
         if ($child_topics->count() == 0) {

--- a/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
+++ b/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
@@ -423,7 +423,7 @@ final class ManageTopicContentForm extends FormBase {
     }
 
     $topic->get('field_topic_content')->setValue($field_topic_content_updated);
-
+    $topic->setRevisionTranslationAffected(TRUE);
     $topic->save();
     $form_state->setRedirect('entity.node.canonical', ['node' => $topic_nid]);
   }

--- a/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
+++ b/web/modules/custom/dept_topics/src/Form/ManageTopicContentForm.php
@@ -424,6 +424,8 @@ final class ManageTopicContentForm extends FormBase {
 
     $topic->get('field_topic_content')->setValue($field_topic_content_updated);
     $topic->setRevisionTranslationAffected(TRUE);
+    $topic->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+    $topic->setRevisionUserId(\Drupal::currentUser()->id());
     $topic->save();
     $form_state->setRedirect('entity.node.canonical', ['node' => $topic_nid]);
   }

--- a/web/modules/custom/dept_topics/src/TopicManager.php
+++ b/web/modules/custom/dept_topics/src/TopicManager.php
@@ -223,6 +223,8 @@ final class TopicManager {
           ]);
           $topic_node->setRevisionLogMessage('Added child: (' . $entity->id() . ') ' . $entity->label());
           $topic_node->setRevisionTranslationAffected(TRUE);
+          $topic_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+          $topic_node->setRevisionUserId(\Drupal::currentUser()->id());
           $topic_node->save();
         }
       }
@@ -250,6 +252,8 @@ final class TopicManager {
         if ($child_removed) {
           $topic_node->setRevisionLogMessage('Removed child: (' . $entity->id() . ') ' . $entity->label());
           $topic_node->setRevisionTranslationAffected(TRUE);
+          $topic_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+          $topic_node->setRevisionUserId(\Drupal::currentUser()->id());
           $topic_node->save();
         }
       }
@@ -281,6 +285,8 @@ final class TopicManager {
 
         $topic_node->setRevisionLogMessage('Removed child: (' . $entity->id() . ') ' . $entity->label());
         $topic_node->setRevisionTranslationAffected(TRUE);
+        $topic_node->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+        $topic_node->setRevisionUserId(\Drupal::currentUser()->id());
         $topic_node->save();
       }
     }

--- a/web/modules/custom/dept_topics/src/TopicManager.php
+++ b/web/modules/custom/dept_topics/src/TopicManager.php
@@ -222,6 +222,7 @@ final class TopicManager {
             'target_id' => $entity->id()
           ]);
           $topic_node->setRevisionLogMessage('Added child: (' . $entity->id() . ') ' . $entity->label());
+          $topic_node->setRevisionTranslationAffected(TRUE);
           $topic_node->save();
         }
       }
@@ -248,6 +249,7 @@ final class TopicManager {
 
         if ($child_removed) {
           $topic_node->setRevisionLogMessage('Removed child: (' . $entity->id() . ') ' . $entity->label());
+          $topic_node->setRevisionTranslationAffected(TRUE);
           $topic_node->save();
         }
       }
@@ -278,6 +280,7 @@ final class TopicManager {
         }
 
         $topic_node->setRevisionLogMessage('Removed child: (' . $entity->id() . ') ' . $entity->label());
+        $topic_node->setRevisionTranslationAffected(TRUE);
         $topic_node->save();
       }
     }


### PR DESCRIPTION
Pagination issue on revisions overview on some nodes is caused by revisions being filtered from the list because the flag revision_translation_affected is NULL.  Fix is to call $topic_node->setRevisionTranslationAffected(TRUE) before $topic_node->save().  Also setting the revision created time and user id is needed.

See https://share.google/aimode/EV9iO2pdYqMdHzCU1 for full explanation 