### PR TITLE
DEPT-1398 Fix incorrect publications path for surrogate-control rule

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -190,7 +190,7 @@ web:
 
       rules:
         # Allow a longer Fastly TTL for publication files
-        '^/sites/default/files/publications/':
+        '^/sites/default/files/([0-9]{4}-[0-9]{2}|publications)/':
           headers:
             Surrogate-Control: max-age=31536000
         # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.


### PR DESCRIPTION
Tested this works on a separate upsun environment - all good