### PR TITLE
Dept 1367

### DIFF
--- a/config/sync/views.view.topics.yml
+++ b/config/sync/views.view.topics.yml
@@ -197,17 +197,11 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: true
+          specify_validation: false
           validate:
-            type: 'entity:node'
+            type: none
             fail: 'not found'
-          validate_options:
-            bundles:
-              subtopic: subtopic
-              topic: topic
-            access: false
-            operation: view
-            multiple: 0
+          validate_options: {  }
           glossary: false
           limit: 0
           case: none

--- a/config/sync/views.view.topics.yml
+++ b/config/sync/views.view.topics.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - flag.flag.hide_listing
+    - node.type.subtopic
     - node.type.topic
     - system.menu.main
   module:
@@ -168,7 +169,7 @@ display:
           exposed: false
           draggable_views_reference: 'topics:page_1'
           draggable_views_null_order: after
-          draggable_views_pass_arguments: false
+          draggable_views_pass_arguments: 0
       arguments:
         field_domain_source_target_id:
           id: field_domain_source_target_id
@@ -196,17 +197,24 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: false
+          specify_validation: true
           validate:
-            type: none
+            type: 'entity:node'
             fail: 'not found'
-          validate_options: {  }
+          validate_options:
+            bundles:
+              subtopic: subtopic
+              topic: topic
+            access: false
+            operation: view
+            multiple: 0
           glossary: false
           limit: 0
           case: none
           path_case: none
           transform_dash: false
           break_phrase: false
+          not: 0
       filters:
         type:
           id: type
@@ -263,7 +271,8 @@ display:
         - url.site
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - flag.flag.hide_listing
   block:
     id: block
     display_title: Block
@@ -350,7 +359,8 @@ display:
         - url.site
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - flag.flag.hide_listing
   page_1:
     id: page_1
     display_title: Admin
@@ -841,7 +851,8 @@ display:
         - url.site
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - flag.flag.hide_listing
   topics_page:
     id: topics_page
     display_title: Page
@@ -937,4 +948,5 @@ display:
         - url.site
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - flag.flag.hide_listing

--- a/web/modules/custom/dept_topics/dept_topics.services.yml
+++ b/web/modules/custom/dept_topics/dept_topics.services.yml
@@ -22,3 +22,9 @@ services:
     arguments: ['@topic.manager', '@orphan.manager', '@entity_type.manager', '@book.manager']
     tags:
       - { name: event_subscriber }
+
+  dept_topics.topics_view_route_subscriber:
+    class: Drupal\dept_topics\Routing\TopicsViewRouteSubscriber
+    tags:
+      - { name: event_subscriber }
+

--- a/web/modules/custom/dept_topics/src/Routing/TopicsViewRouteSubscriber.php
+++ b/web/modules/custom/dept_topics/src/Routing/TopicsViewRouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\dept_topics\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Alters topic routes.
+ */
+class TopicsViewRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('view.topics.topics_page')) {
+      $route->setPath('/topics');
+      $route->setOption('_view_argument_map', []);
+    }
+  }
+
+}


### PR DESCRIPTION
Another crack at this one... :)

 ## Summary

Fixes the Topics view route so /topics remains an exact listing page route and no longer captures topic/subtopic aliases as views contextual args.

  ## Detail

  - Removes invalid contextual arg validation from views.view.topics.yml.
  - Restores the active domain contextual filter so /topics correctly defaults to the current domain.
  - Adds a route subscriber to force the views page route to /topics and clear the views argument map.
  - This leaves /topics/{alias} paths to Drupal’s normal path alias routing.

  ## Check with

  - /topics lists only active domain topics.
  - /topics/statistics-and-research is handled as a topic alias, not a views argument.
  - /topics/statistics-and-research-1%C2%A0 returns 404 instead of 500 as it's not a valid node alias.