### PR TITLE
Swap listings to default to no cache tag policy to avoid unwanted cache expiration bubble

### DIFF
--- a/.ddev/commands/web/drupal-check
+++ b/.ddev/commands/web/drupal-check
@@ -6,4 +6,4 @@
 ## Example: "ddev <drupal-check|drck> web/modules/custom"
 ## HostWorkingDir: true
 
-/var/www/html/vendor/bin/drupal-check ./
+/var/www/html/vendor/bin/drupal-check $1

--- a/config/sync/views.view.consultations_search.yml
+++ b/config/sync/views.view.consultations_search.yml
@@ -137,7 +137,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: search_api_tag
+        type: search_api_none
         options: {  }
       empty: {  }
       sorts:

--- a/config/sync/views.view.events.yml
+++ b/config/sync/views.view.events.yml
@@ -133,7 +133,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: search_api_tag
+        type: search_api_none
         options: {  }
       empty:
         area:
@@ -466,6 +466,7 @@ display:
     display_options:
       cache:
         type: search_api_none
+        options: {  }
       defaults:
         cache: false
         css_class: false

--- a/config/sync/views.view.publications_search.yml
+++ b/config/sync/views.view.publications_search.yml
@@ -350,7 +350,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: search_api_tag
+        type: search_api_none
         options: {  }
       empty: {  }
       sorts:

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -598,6 +598,9 @@ display:
         operator: AND
         groups:
           1: AND
+      cache:
+        type: search_api_none
+        options: {  }
       style:
         type: default
         options:
@@ -614,6 +617,7 @@ display:
       defaults:
         empty: false
         css_class: true
+        cache: false
         pager: false
         exposed_form: false
         style: false

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -499,6 +499,9 @@ display:
           expose_sort_order: false
           sort_asc_label: Asc
           sort_desc_label: Desc
+      cache:
+        type: search_api_none
+        options: {  }
       empty: {  }
       sorts:
         search_api_relevance:
@@ -598,9 +601,6 @@ display:
         operator: AND
         groups:
           1: AND
-      cache:
-        type: search_api_none
-        options: {  }
       style:
         type: default
         options:
@@ -616,8 +616,8 @@ display:
           hide_empty: false
       defaults:
         empty: false
-        css_class: true
         cache: false
+        css_class: true
         pager: false
         exposed_form: false
         style: false

--- a/config/sync/views.view.topics.yml
+++ b/config/sync/views.view.topics.yml
@@ -13,6 +13,8 @@ dependencies:
     - flag
     - node
     - user
+    - handy_cache_tags
+    - views_custom_cache_tag
 id: topics
 label: Topics
 module: views
@@ -149,8 +151,13 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
-        options: {  }
+        type: custom_tag
+        options:
+          custom_tag: |-
+            handy_cache_tags:node:topic
+            handy_cache_tags:node:subtopic
+          custom_tag_output_lifespan: '-1'
+          custom_tag_output_lifespan_expression: ''
       empty: {  }
       sorts:
         weight:
@@ -168,7 +175,7 @@ display:
           exposed: false
           draggable_views_reference: 'topics:page_1'
           draggable_views_null_order: after
-          draggable_views_pass_arguments: false
+          draggable_views_pass_arguments: 0
       arguments:
         field_domain_source_target_id:
           id: field_domain_source_target_id

--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -9,6 +9,9 @@ use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\AppendCommand;
 use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Ajax\RemoveCommand;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
@@ -21,6 +24,7 @@ use Drupal\media\Entity\Media;
 use Drupal\media\MediaInterface;
 use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeInterface;
+use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\views\ViewExecutable;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -54,9 +58,13 @@ function dept_node_form_views_exposed_form_alter(&$form, FormStateInterface $for
 /**
  * Implements hook_form_ENTITY_form_alter().
  */
-function dept_node_form_node_form_alter(&$form, $form_state) {
+function dept_node_form_node_form_alter(&$form, FormStateInterface $form_state) {
+  $entity = dept_node_get_form_entity($form_state);
+  if ($entity === NULL) {
+    return;
+  }
   // Add handler to process nodes that should have 'nigov' entries.
-  if (in_array($form_state->getFormObject()->getEntity()->bundle(), [
+  if (in_array($entity->bundle(), [
     'consultation',
     'publication',
     'news'
@@ -109,7 +117,7 @@ function dept_node_form_node_form_alter(&$form, $form_state) {
       $form['field_domain_source']['widget']['#default_value'][] = $domain_access_ids[0];
     }
     else {
-      \Drupal::logger('dept_node')->error("Domain access ID's not found for entity: @entity", ['@entity' => $form_state->getFormObject()->getEntity()->getEntityTypeId()]);
+      \Drupal::logger('dept_node')->error("Domain access ID's not found for entity: @entity", ['@entity' => $entity->getEntityTypeId()]);
     }
   }
 
@@ -137,6 +145,21 @@ function dept_node_form_node_form_alter(&$form, $form_state) {
 }
 
 /**
+ * Gets the entity from an entity form state.
+ *
+ *  \Drupal\Core\Entity\EntityInterface|null
+ *   The form entity, or NULL when the callback is used on a non-entity form.
+ */
+function dept_node_get_form_entity(FormStateInterface $form_state): ?EntityInterface {
+  $form_object = $form_state->getFormObject();
+  if (!$form_object instanceof EntityFormInterface) {
+    return NULL;
+  }
+
+  return $form_object->getEntity();
+}
+
+/**
  * Callback for title field ajax call to warn user of existing title.
  */
 function dept_node_title_guardian(array &$form, FormStateInterface $form_state) {
@@ -147,9 +170,11 @@ function dept_node_title_guardian(array &$form, FormStateInterface $form_state) 
   }
 
   $title = trim($form_state->getValue('title')[0]['value']);
-
-  // @phpstan-ignore-next-line
-  $bundle = $form_state->getformObject()->getEntity()->bundle();
+  $entity = dept_node_get_form_entity($form_state);
+  if ($entity === NULL) {
+    return new AjaxResponse();
+  }
+  $bundle = $entity->bundle();
 
   // Check for existing titles within the same department and content type.
   $query = \Drupal::database()->select('node_field_data', 'fd');
@@ -207,6 +232,147 @@ function dept_node_views_pre_render(ViewExecutable $view) {
         ->addWarning('NB: Title altered in dept_node_views_pre_render()');
     }
   }
+}
+
+/**
+ * Implements hook_views_post_render().
+ *
+ * Public node-based Views normally bubble Drupal's generic `node_list` cache
+ * tag. That tag is invalidated whenever any node is created, updated, or
+ * deleted, so one Finance edit can purge cached listing blocks on every other
+ * department site.
+ *
+ * For non-admin Views built from `node_field_data`, replace `node_list` with a
+ * domain-specific tag such as `dept_node_list:finance`. The matching
+ * invalidation happens in dept_node_invalidate_domain_list_cache(), which works
+ * out the affected domain(s) from `field_domain_access` and
+ * `field_domain_source`.
+ *
+ * Admin listings are deliberately left alone. Editors and administrators expect
+ * those listings to reflect all node changes immediately, and they are not part
+ * of the public page-cache/purge problem this hook is addressing.
+ */
+function dept_node_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
+  if (!dept_node_should_scope_node_list_cache_tag($view)) {
+    return;
+  }
+
+  if (!is_array($output)) {
+    return;
+  }
+
+  $tags = $output['#cache']['tags'] ?? [];
+  if (!in_array('node_list', $tags, TRUE)) {
+    return;
+  }
+
+  $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
+  $output['#cache']['tags'] = Cache::mergeTags(
+    array_values(array_diff($tags, ['node_list'])),
+    ['dept_node_list:' . $active_domain->id()]
+  );
+}
+
+/**
+ * Determines whether a view should use domain-scoped public node list tags.
+ */
+function dept_node_should_scope_node_list_cache_tag(ViewExecutable $view) {
+  if ($view->storage->get('base_table') !== 'node_field_data') {
+    return FALSE;
+  }
+
+  if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+    return FALSE;
+  }
+
+  $display = $view->storage->get('display')[$view->current_display] ?? [];
+  $path = $display['display_options']['path'] ?? '';
+  if (str_starts_with($path, 'admin/')) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function dept_node_entity_insert(EntityInterface $entity) {
+  dept_node_invalidate_domain_list_cache($entity);
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function dept_node_entity_update(EntityInterface $entity) {
+  dept_node_invalidate_domain_list_cache($entity);
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function dept_node_entity_delete(EntityInterface $entity) {
+  dept_node_invalidate_domain_list_cache($entity);
+}
+
+/**
+ * Invalidates public node-list render cache entries for affected domains.
+ *
+ * Public node listing Views replace Drupal's broad `node_list` cache tag with
+ * `dept_node_list:{domain_id}`. This function invalidates only those scoped
+ * tags when a node changes.
+ *
+ * Examples:
+ * - A Finance-only article invalidates `dept_node_list:finance`.
+ * - A news item shared between Finance and NIGov invalidates
+ *   `dept_node_list:finance` and `dept_node_list:nigov`.
+ * - If a node is moved from Finance to Economy, both the old Finance list and
+ *   the new Economy list are invalidated because `$entity->original` is merged
+ *   with the saved entity values.
+ * - If a node has no domain values, all department list tags are invalidated as
+ *   a conservative fallback.
+ */
+function dept_node_invalidate_domain_list_cache(EntityInterface $entity) {
+  if (!$entity instanceof NodeInterface) {
+    return;
+  }
+
+  $domains = dept_node_get_entity_domain_ids($entity);
+  if (!empty($entity->original) && $entity->original instanceof NodeInterface) {
+    $domains = array_merge($domains, dept_node_get_entity_domain_ids($entity->original));
+  }
+
+  $domains = array_values(array_unique(array_filter($domains)));
+  if (empty($domains)) {
+    $domains = array_keys(\Drupal::service('department.manager')->getAllDepartments());
+  }
+
+  $tags = array_map(function ($domain_id) {
+    return 'dept_node_list:' . $domain_id;
+  }, $domains);
+
+  Cache::invalidateTags($tags);
+}
+
+/**
+ * Gets every domain that can be affected by a node list membership change.
+ */
+function dept_node_get_entity_domain_ids(NodeInterface $node) {
+  $domain_ids = [];
+
+  foreach (['field_domain_access', 'field_domain_source'] as $field_name) {
+    if (!$node->hasField($field_name) || $node->get($field_name)->isEmpty()) {
+      continue;
+    }
+
+    foreach ($node->get($field_name)->getValue() as $value) {
+      if (!empty($value['target_id'])) {
+        $domain_ids[] = $value['target_id'];
+      }
+    }
+  }
+
+  return $domain_ids;
 }
 
 /**
@@ -337,9 +503,12 @@ function dept_node_pathauto_alias_alter(&$alias, array &$context) {
  */
 function dept_node_assign_domain_defaults(array $form, FormStateInterface $form_state) {
   $domain_access = $form_state->getValue('field_domain_access');
+  $entity = dept_node_get_form_entity($form_state);
+  if ($entity === NULL) {
+    return;
+  }
 
-  // @phpstan-ignore-next-line
-  if ($form_state->getFormObject()->getEntity()->bundle() === 'news') {
+  if ($entity->bundle() === 'news') {
     $dept = \Drupal::service('department.manager')->getCurrentDepartment()->id();
     $type = $form_state->getValue('field_news_type')[0]['value'];
     // If News is not a press release created on nigov, remove any existing 'nigov' entry.
@@ -367,8 +536,12 @@ function dept_node_assign_domain_defaults(array $form, FormStateInterface $form_
  * as the nigov domain.
  */
 function dept_node_assign_domain_defaults_media(array $form, FormStateInterface $form_state, array $node_domain_access_values) {
-  // @phpstan-ignore-next-line
-  $bundle = $form_state->getFormObject()->getEntity()->bundle();
+  $entity = dept_node_get_form_entity($form_state);
+  if ($entity === NULL) {
+    return;
+  }
+
+  $bundle = $entity->bundle();
 
   // Replicate the domain access settings on any referenced media entities.
   $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions('node', $bundle);

--- a/web/modules/custom/dept_search/dept_search.module
+++ b/web/modules/custom/dept_search/dept_search.module
@@ -6,10 +6,12 @@
  */
 
 use Drupal\Core\Url;
+use Drupal\dept_search\Cache\BroadSearchCacheTags;
 use Drupal\block\Entity\Block;
 use Drupal\dept_core\Entity\Department;
 use Drupal\facets\FacetInterface;
 use Drupal\facets_summary\Entity\FacetsSummary;
+use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -135,6 +137,25 @@ function dept_search_views_pre_view(ViewExecutable $view, $display_id, array &$a
       $args[0] = $active_dept->id();
     }
   }
+}
+
+/**
+ * Implements hook_views_post_render().
+ */
+function dept_search_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
+  if ($view->id() !== 'search' || $view->current_display !== 'site_search_embed') {
+    return;
+  }
+
+  if (!is_array($output)) {
+    return;
+  }
+
+  // The header search only renders a form. Its cached page shell does not need
+  // to be invalidated when indexed content or autocomplete suggestions change.
+  $output['#cache']['tags'] = BroadSearchCacheTags::removeBroadTags(
+    $output['#cache']['tags'] ?? []
+  );
 }
 
 /**

--- a/web/modules/custom/dept_search/dept_search.services.yml
+++ b/web/modules/custom/dept_search/dept_search.services.yml
@@ -1,4 +1,8 @@
 services:
+  dept_search.header_search_cache_tags_subscriber:
+    class: Drupal\dept_search\EventSubscriber\HeaderSearchCacheTagsSubscriber
+    tags:
+      - { name: event_subscriber }
   prettypathstostandardfacets:
     class: Drupal\dept_search\EventSubscriber\PrettyPathsToStandardFacets
     tags:

--- a/web/modules/custom/dept_search/src/Cache/BroadSearchCacheTags.php
+++ b/web/modules/custom/dept_search/src/Cache/BroadSearchCacheTags.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\dept_search\Cache;
+
+/**
+ * Identifies broad Search API cache tags used by public search listings.
+ */
+final class BroadSearchCacheTags {
+
+  /**
+   * Search API tag prefixes that cause whole-index public listing purges.
+   */
+  public const PREFIXES = [
+    'search_api_list:',
+    'search_api_autocomplete_search_list:views:',
+  ];
+
+  /**
+   * Removes broad Search API tags from a cache tag list.
+   *
+   * @param string[] $tags
+   *   Cache tags to filter.
+   *
+   * @return string[]
+   *   Cache tags that do not match the broad Search API prefixes.
+   */
+  public static function removeBroadTags(array $tags): array {
+    return array_values(array_diff($tags, self::findBroadTags($tags)));
+  }
+
+  /**
+   * Finds broad Search API tags that should not bubble to public pages.
+   *
+   * @param string[] $tags
+   *   Cache tags to inspect.
+   *
+   * @return string[]
+   *   Broad Search API tags.
+   */
+  public static function findBroadTags(array $tags): array {
+    return array_values(array_filter($tags, static function (string $tag): bool {
+      foreach (self::PREFIXES as $prefix) {
+        if (str_starts_with($tag, $prefix)) {
+          return TRUE;
+        }
+      }
+
+      return FALSE;
+    }));
+  }
+
+}

--- a/web/modules/custom/dept_search/src/EventSubscriber/HeaderSearchCacheTagsSubscriber.php
+++ b/web/modules/custom/dept_search/src/EventSubscriber/HeaderSearchCacheTagsSubscriber.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\dept_search\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\dept_search\Cache\BroadSearchCacheTags;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Removes content-list cache tags added by the global header search form.
+ */
+class HeaderSearchCacheTagsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Removes broad Search API list tags from non-search page responses.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response event object.
+   */
+  public function onResponse(ResponseEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    // Keep autocomplete itself and administration pages fully cache-tagged.
+    // Public pages keep entity-specific tags, but not whole-index tags that
+    // purge unrelated domains when any indexed content changes.
+    if (\Drupal::routeMatch()->getRouteName() === 'search_api_autocomplete.autocomplete'
+      || \Drupal::service('router.admin_context')->isAdminRoute()) {
+      return;
+    }
+
+    $response = $event->getResponse();
+    if ($response->headers->has('X-Drupal-Cache-Tags')) {
+      $cache_tags_header = $response->headers->get('X-Drupal-Cache-Tags');
+      $cache_tags = explode(' ', $cache_tags_header);
+      $broad_search_tags = BroadSearchCacheTags::findBroadTags($cache_tags);
+
+      // Keep every existing tag except the broad Search API tags.
+      $cache_tags_to_keep = array_values(array_diff($cache_tags, $broad_search_tags));
+      $response->headers->set('X-Drupal-Cache-Tags', implode(' ', $cache_tags_to_keep));
+    }
+
+    if (!$response instanceof CacheableResponseInterface) {
+      return;
+    }
+
+    $metadata = $response->getCacheableMetadata();
+    $metadata->setCacheTags(BroadSearchCacheTags::removeBroadTags(
+      $metadata->getCacheTags()
+    ));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse', 100];
+    $events[KernelEvents::RESPONSE][] = ['onResponse', -100];
+    return $events;
+  }
+
+}

--- a/web/sites/default/services.yml
+++ b/web/sites/default/services.yml
@@ -125,7 +125,7 @@ parameters:
   #
   # Not recommended in production environments
   # @default false
-  http.response.debug_cacheability_headers: false
+  http.response.debug_cacheability_headers: true
   factory.keyvalue:
     {}
     # Default key/value storage service to use.


### PR DESCRIPTION
Counter intuitive at first glance, but what this appears to show is that removing the views level cache tagging process and relying on Drupal's dynamic and general page cache still ensures cache control headers are set on the listing pages. BUT crucially, editing a news node doesn't then trigger expirations for unrelated nodes such as publication nodes. Subsequent views of those pages after editing a node still shows cached responses and only the edited node is regenerated with later views returning the new cached response.

Would like to test this on Upsun to further make sure nothing's been missed.