### PR TITLE
Dept 1373

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "dimsemenov/photoswipe": "^5.4",
         "dimsemenov/photoswipe-dynamic-caption-plugin": "^1.2",
         "doctrine/annotations": "^2.0",
-        "dof-dss/nicsdru_origins_modules": "^10.6",
+        "dof-dss/nicsdru_origins_modules": "^10.7",
         "dof-dss/nicsdru_origins_theme": "^10.1",
         "drupal/a11y_form_helpers": "^2.1",
         "drupal/address": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a10552272fdd9372e98fb6dd610e1373",
+    "content-hash": "d40175dac060691901e2bfa6a236e7c6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1427,28 +1427,32 @@
         },
         {
             "name": "dof-dss/nicsdru_origins_modules",
-            "version": "10.6.6",
+            "version": "10.7.0",
             "source": {
                 "type": "git",
                 "url": "git@github.com:dof-dss/nicsdru_origins_modules.git",
-                "reference": "80481d602c6c3f2aea7054ac790ebfe366f649dc"
+                "reference": "c94c9f5871c4cd090db5fed839abbad413041280"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dof-dss/nicsdru_origins_modules/zipball/80481d602c6c3f2aea7054ac790ebfe366f649dc",
-                "reference": "80481d602c6c3f2aea7054ac790ebfe366f649dc",
+                "url": "https://api.github.com/repos/dof-dss/nicsdru_origins_modules/zipball/c94c9f5871c4cd090db5fed839abbad413041280",
+                "reference": "c94c9f5871c4cd090db5fed839abbad413041280",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "^2.0",
                 "drupal/core": "^10"
             },
+            "bin": [
+                "bin/dof-dss-filehash",
+                "bin/dof-dss-mediahasher"
+            ],
             "type": "drupal-module",
             "license": [
                 "MIT"
             ],
             "description": "Generic modules for DOF-DSS Drupal sites",
-            "time": "2026-04-16T09:38:23+00:00"
+            "time": "2026-06-02T15:38:26+00:00"
         },
         {
             "name": "dof-dss/nicsdru_origins_theme",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -201,6 +201,7 @@ module:
   workflows: 0
   http_cache_control: 1
   pathauto: 1
+  origins_cache_control: 2
   origins_workflow: 2
   views: 10
   paragraphs: 11

--- a/config/sync/http_cache_control.settings.yml
+++ b/config/sync/http_cache_control.settings.yml
@@ -6,14 +6,16 @@ cache:
     404_max_age: 0
     302_max_age: 0
     301_max_age: 0
-    5xx_max_age: 0
     stale_while_revalidate: 180
     stale_if_error: 180
     vary: ''
     mustrevalidate: true
     nocache: false
     nostore: false
+    5xx_max_age: 0
     cookieextra: null
   surrogate:
-    maxage: 86400
+    maxage: 31536000
     nostore: false
+  targeted:
+    items: {  }


### PR DESCRIPTION
Origins point release includes origins_cache_control module which takes code originally from NIDirect and makes it more usable across projects.

Enable it, set required surrogate TTL, export config, make sure origins_cache_control has a weight higher than http_cache_control module in core.extension.yml and you should be good to go.