### PR TITLE
Fix gallery image captions

### DIFF
--- a/config/sync/core.entity_view_display.node.gallery.full.yml
+++ b/config/sync/core.entity_view_display.node.gallery.full.yml
@@ -51,7 +51,7 @@ content:
       photoswipe_view_mode: full
     third_party_settings:
       photoswipe_dynamic_caption:
-        photoswipe_caption: title
+        photoswipe_caption: photoswipe_dynamic_caption_referenced_entity_field_caption
         photoswipe_caption_custom: ''
     weight: 3
     region: content

--- a/web/themes/custom/nicsdru_dept_theme/inc/preprocess.inc
+++ b/web/themes/custom/nicsdru_dept_theme/inc/preprocess.inc
@@ -641,18 +641,22 @@ function nicsdru_dept_theme_preprocess_responsive_image_formatter(array &$variab
     return;
   }
 
-  // If we've got a parent media entity and caption field value
-  // then inject the value into the responsive image attributes collection.
+  // If we've got a parent media entity, inject its caption field value
+  // into the responsive image attributes collection, falling back to title
+  // when no caption is present.
   // We're relying on Drupal input sanitising from the media form as
   // well as safe Twig rendering in responsive-image.html.twig to cover
   // any content that is migrated in from the legacy db and could
   // potentially contain dodgy html.
   $caption = $media_image->get('field_caption')->value;
 
-  if (!empty($caption)) {
-    if ($variables['responsive_image_style_id'] != 'featured_news_thumbnail') {
-      $variables['responsive_image']['#attributes']['caption'] = $caption;
-    }
+  if (empty($caption) && $media_image->hasField('field_media_image')) {
+    $image = $media_image->get('field_media_image')->first();
+    $caption = $image->title ?? '';
+  }
+
+  if (!empty($caption) && $variables['responsive_image_style_id'] != 'featured_news_thumbnail') {
+    $variables['responsive_image']['#attributes']['caption'] = $caption;
   }
 }
 

--- a/web/themes/custom/nicsdru_dept_theme/inc/preprocess.inc
+++ b/web/themes/custom/nicsdru_dept_theme/inc/preprocess.inc
@@ -657,6 +657,25 @@ function nicsdru_dept_theme_preprocess_responsive_image_formatter(array &$variab
 }
 
 /**
+ * Implements hook_preprocess_photoswipe_responsive_image_formatter().
+ */
+function nicsdru_dept_theme_preprocess_photoswipe_responsive_image_formatter(array &$variables) {
+  if (!empty($variables['attributes']['data-overlay-title'])) {
+    return;
+  }
+
+  $media_image = $variables['item']->entity ?? NULL;
+  if ($media_image instanceof MediaInterface === FALSE || !$media_image->hasField('field_media_image')) {
+    return;
+  }
+
+  $image = $media_image->get('field_media_image')->first();
+  if ($image && !empty($image->title)) {
+    $variables['attributes']['data-overlay-title'] = $image->title;
+  }
+}
+
+/**
  * Implements template_preprocess_container().
  */
 function nicsdru_dept_theme_preprocess_container(&$variables) {

--- a/web/themes/custom/nicsdru_dept_theme/templates/field/responsive-image--gallery.html.twig
+++ b/web/themes/custom/nicsdru_dept_theme/templates/field/responsive-image--gallery.html.twig
@@ -14,7 +14,9 @@
  */
 #}
 
-{% if img_element['#title'] %}
+{% set caption = img_element['#attributes']['caption']|default(img_element['#title']|default('')) %}
+
+{% if caption %}
   <figure>
 {% endif %}
 {% if output_image_tag %}
@@ -30,8 +32,8 @@
       {{ img_element }}
     </picture>
 {% endif %}
-{% if img_element['#title'] %}
-    <figcaption class="field-file-image-caption-text">{{ img_element['#title'] }}</figcaption>
+{% if caption %}
+    <figcaption class="field-file-image-caption-text">{{ caption }}</figcaption>
   </figure>
 {% endif %}
 

--- a/web/themes/custom/nicsdru_dept_theme/templates/field/responsive-image--gallery.html.twig
+++ b/web/themes/custom/nicsdru_dept_theme/templates/field/responsive-image--gallery.html.twig
@@ -14,7 +14,7 @@
  */
 #}
 
-{% set caption = img_element['#attributes']['caption']|default(img_element['#title']|default('')) %}
+{% set caption = img_element['#attributes']['caption']|default('') %}
 
 {% if caption %}
   <figure>


### PR DESCRIPTION
Render gallery figcaptions from the media caption field, falling back to the image title when no caption is provided. Configure PhotoSwipe to use the media caption field and add the same title fallback for overlay captions.