### PR TITLE
block_related_content: replace node_list with related_content tags

### DIFF
--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -247,6 +247,11 @@ function dept_node_views_pre_render(ViewExecutable $view) {
  * dept_node_invalidate_related_content_cache(), which works out the affected
  * topic(s) from `field_site_topics`.
  *
+ * For the latest_news view, replace node_list with `dept_latest_news:{domain}`.
+ * The matching invalidation happens in dept_node_invalidate_latest_news_cache(), which works
+ * out the affected domain(s) from `field_domain_access` and
+ * `field_domain_source`.
+ *
  * For all other non-admin Views built from `node_field_data`, replace `node_list`
  * with a domain-specific tag such as `dept_node_list:finance`. The matching
  * invalidation happens in dept_node_invalidate_domain_list_cache(), which works
@@ -287,9 +292,21 @@ function dept_node_views_post_render(ViewExecutable $view, &$output, CachePlugin
     }
   }
 
-  // For all other non-admin node views, replace node_list with a
-  // domain-specific tag.
   $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
+
+  // For the latest_news view (on news pages), replace node_list with
+  // dept_latest_news:{domain}
+  if (dept_node_is_latest_news_view($view)) {
+    $output['#cache']['tags'] = Cache::mergeTags(
+      array_values(array_diff($tags, ['node_list'])),
+      ['dept_latest_news:' . $active_domain->id()]
+    );
+
+    return;
+  }
+
+  // For all other non-admin node views, replace node_list with a
+  // generic domain-specific tag.
   $output['#cache']['tags'] = Cache::mergeTags(
     array_values(array_diff($tags, ['node_list'])),
     ['dept_node_list:' . $active_domain->id()]
@@ -322,6 +339,7 @@ function dept_node_should_scope_node_list_cache_tag(ViewExecutable $view) {
  */
 function dept_node_entity_insert(EntityInterface $entity) {
   dept_node_invalidate_domain_list_cache($entity);
+  dept_node_invalidate_latest_news_cache($entity);
   dept_node_invalidate_related_content_cache($entity);
 }
 
@@ -330,6 +348,7 @@ function dept_node_entity_insert(EntityInterface $entity) {
  */
 function dept_node_entity_update(EntityInterface $entity) {
   dept_node_invalidate_domain_list_cache($entity);
+  dept_node_invalidate_latest_news_cache($entity);
   dept_node_invalidate_related_content_cache($entity);
 }
 
@@ -338,6 +357,7 @@ function dept_node_entity_update(EntityInterface $entity) {
  */
 function dept_node_entity_delete(EntityInterface $entity) {
   dept_node_invalidate_domain_list_cache($entity);
+  dept_node_invalidate_latest_news_cache($entity);
   dept_node_invalidate_related_content_cache($entity);
 }
 
@@ -380,6 +400,32 @@ function dept_node_invalidate_domain_list_cache(EntityInterface $entity) {
   Cache::invalidateTags($tags);
 }
 
+function dept_node_invalidate_latest_news_cache(EntityInterface $entity) {
+  if (!$entity instanceof NodeInterface) {
+    return;
+  }
+
+  if ($entity->bundle() !== 'news') {
+    return;
+  }
+
+  $domains = dept_node_get_entity_domain_ids($entity);
+  if (!empty($entity->original) && $entity->original instanceof NodeInterface) {
+    $domains = array_merge($domains, dept_node_get_entity_domain_ids($entity->original));
+  }
+
+  $domains = array_values(array_unique(array_filter($domains)));
+  if (empty($domains)) {
+    $domains = array_keys(\Drupal::service('department.manager')->getAllDepartments());
+  }
+
+  $tags = array_map(function ($domain_id) {
+    return 'dept_latest_news:' . $domain_id;
+  }, $domains);
+
+  Cache::invalidateTags($tags);
+}
+
 /**
  * Gets every domain that can be affected by a node list membership change.
  */
@@ -407,6 +453,14 @@ function dept_node_get_entity_domain_ids(NodeInterface $node) {
 function dept_node_is_related_content_view(ViewExecutable $view) {
   return $view->id() === 'content_by_site_subtopic'
     && $view->current_display === 'block_related_content';
+}
+
+/**
+ * Determines whether a view is the latest_news view.
+ */
+function dept_node_is_latest_news_view(ViewExecutable $view) {
+  return $view->id() === 'news'
+    && $view->current_display === 'latest_news';
 }
 
 /**

--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -295,7 +295,7 @@ function dept_node_views_post_render(ViewExecutable $view, &$output, CachePlugin
   $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
 
   // For the latest_news view (on news pages), replace node_list with
-  // dept_latest_news:{domain}
+  // dept_latest_news:{domain}.
   if (dept_node_is_latest_news_view($view)) {
     $output['#cache']['tags'] = Cache::mergeTags(
       array_values(array_diff($tags, ['node_list'])),
@@ -400,6 +400,9 @@ function dept_node_invalidate_domain_list_cache(EntityInterface $entity) {
   Cache::invalidateTags($tags);
 }
 
+/**
+ * Invalidates latest_news cache tags for affected domains.
+ */
 function dept_node_invalidate_latest_news_cache(EntityInterface $entity) {
   if (!$entity instanceof NodeInterface) {
     return;

--- a/web/modules/custom/dept_node/dept_node.module
+++ b/web/modules/custom/dept_node/dept_node.module
@@ -242,8 +242,13 @@ function dept_node_views_pre_render(ViewExecutable $view) {
  * deleted, so one Finance edit can purge cached listing blocks on every other
  * department site.
  *
- * For non-admin Views built from `node_field_data`, replace `node_list` with a
- * domain-specific tag such as `dept_node_list:finance`. The matching
+ * For the block_related_content view, replace node_list with a tag such as
+ * `related_content:{topic_nid}`. The matching invalidation happens in
+ * dept_node_invalidate_related_content_cache(), which works out the affected
+ * topic(s) from `field_site_topics`.
+ *
+ * For all other non-admin Views built from `node_field_data`, replace `node_list`
+ * with a domain-specific tag such as `dept_node_list:finance`. The matching
  * invalidation happens in dept_node_invalidate_domain_list_cache(), which works
  * out the affected domain(s) from `field_domain_access` and
  * `field_domain_source`.
@@ -266,6 +271,24 @@ function dept_node_views_post_render(ViewExecutable $view, &$output, CachePlugin
     return;
   }
 
+  // The related content view depends on the topics a node is tagged
+  // with. Replace the node_list tag with related_content:{topic_nid}
+  // for each topic referenced by the current node.
+  if (dept_node_is_related_content_view($view)) {
+    $node = \Drupal::routeMatch()->getParameter('node');
+
+    if ($node instanceof NodeInterface) {
+      $output['#cache']['tags'] = Cache::mergeTags(
+        array_values(array_diff($tags, ['node_list'])),
+        dept_node_get_related_content_cache_tags($node)
+      );
+
+      return;
+    }
+  }
+
+  // For all other non-admin node views, replace node_list with a
+  // domain-specific tag.
   $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
   $output['#cache']['tags'] = Cache::mergeTags(
     array_values(array_diff($tags, ['node_list'])),
@@ -299,6 +322,7 @@ function dept_node_should_scope_node_list_cache_tag(ViewExecutable $view) {
  */
 function dept_node_entity_insert(EntityInterface $entity) {
   dept_node_invalidate_domain_list_cache($entity);
+  dept_node_invalidate_related_content_cache($entity);
 }
 
 /**
@@ -306,6 +330,7 @@ function dept_node_entity_insert(EntityInterface $entity) {
  */
 function dept_node_entity_update(EntityInterface $entity) {
   dept_node_invalidate_domain_list_cache($entity);
+  dept_node_invalidate_related_content_cache($entity);
 }
 
 /**
@@ -313,6 +338,7 @@ function dept_node_entity_update(EntityInterface $entity) {
  */
 function dept_node_entity_delete(EntityInterface $entity) {
   dept_node_invalidate_domain_list_cache($entity);
+  dept_node_invalidate_related_content_cache($entity);
 }
 
 /**
@@ -373,6 +399,85 @@ function dept_node_get_entity_domain_ids(NodeInterface $node) {
   }
 
   return $domain_ids;
+}
+
+/**
+ * Determines whether a view is the block_related_content view.
+ */
+function dept_node_is_related_content_view(ViewExecutable $view) {
+  return $view->id() === 'content_by_site_subtopic'
+    && $view->current_display === 'block_related_content';
+}
+
+/**
+ * Gets cache tags for the related-content listings associated with a
+ * node's topics.
+ */
+function dept_node_get_related_content_cache_tags(NodeInterface $node) {
+  return array_map(
+    fn ($id) => 'related_content:' . $id,
+    dept_node_get_topic_node_ids($node)
+  );
+}
+
+/**
+ * Gets the related-content cache tags that may be affected by changes
+ * to a node and will need invalidated.
+ */
+function dept_node_get_related_content_invalidation_tags(NodeInterface $node) {
+  $topic_ids = dept_node_get_topic_node_ids($node);
+
+  if (!empty($node->original) && $node->original instanceof NodeInterface) {
+    $topic_ids = array_merge(
+      $topic_ids,
+      dept_node_get_topic_node_ids($node->original)
+    );
+  }
+
+  $topic_ids = array_values(array_unique($topic_ids));
+
+  return array_map(function ($topic_id) {
+    return 'related_content:' . $topic_id;
+  }, $topic_ids);
+}
+
+/**
+ * Invalidates related-content cache entries for a node's topics.
+ */
+function dept_node_invalidate_related_content_cache(EntityInterface $entity) {
+  if (!$entity instanceof NodeInterface) {
+    return;
+  }
+
+  $tags = dept_node_get_related_content_invalidation_tags($entity);
+
+  if (!$tags) {
+    return;
+  }
+
+  \Drupal::logger('dept_node')->notice(
+    'Invalidating related content tags: @tags',
+    ['@tags' => implode(', ', $tags)]
+  );
+
+  Cache::invalidateTags($tags);
+}
+
+/**
+ * Gets the topic node IDs referenced by a node.
+ */
+function dept_node_get_topic_node_ids(NodeInterface $node) {
+  $ids = [];
+
+  if (!$node->hasField('field_site_topics')) {
+    return $ids;
+  }
+
+  foreach ($node->get('field_site_topics')->referencedEntities() as $topic) {
+    $ids[] = $topic->id();
+  }
+
+  return array_values(array_unique($ids));
 }
 
 /**


### PR DESCRIPTION
Expands on Johan's existing code for replacing node_list tag on node views with dept_node_list.  For views of related content shown on article pages, the view depends on the topics a node is assigned with. So we can replace node_list with related_content:{topic_nid} and invalidate those tags when a node is changed.  This hopefully delivers highly targeted article cache purges.