### PR TITLE
DEPT-1457 ~ Report any URL's that could not be parsed

### DIFF
--- a/web/modules/custom/dept_core/modules/dept_content_processors/src/Plugin/Filter/AbsToRelUrlsFilter.php
+++ b/web/modules/custom/dept_core/modules/dept_content_processors/src/Plugin/Filter/AbsToRelUrlsFilter.php
@@ -4,7 +4,6 @@ namespace Drupal\dept_content_processors\Plugin\Filter;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\dept_core\DepartmentManager;
 use Drupal\dept_core\Entity\Department;
 use Drupal\filter\FilterProcessResult;
 use Drupal\filter\Plugin\FilterBase;
@@ -118,6 +117,15 @@ class AbsToRelUrlsFilter extends FilterBase implements ContainerFactoryPluginInt
           // then remove the hostname from the attribute and update the
           // dom element.
           $url_portions = parse_url($href);
+
+          // Report any corrupted URL's.
+          if ($url_portions === FALSE) {
+            \Drupal::logger('dept_content_processors')->warning('Could not parse %site url: %url', [
+              '%site' => $this->departmentId,
+              '%url' => $href
+            ]);
+            continue;
+          }
 
           if ($this->shouldRewriteUrl($url_portions) && $this->hostnameMatchesKnownDepartment($href)) {
 


### PR DESCRIPTION
No need to inject the logger as this rarely happens so it's more performant to call it statically.